### PR TITLE
Repair set_uploader args

### DIFF
--- a/pyupdater/core.py
+++ b/pyupdater/core.py
@@ -67,14 +67,14 @@ class PyUpdater(object):
         """
         self.ph.process_packages(report_errors)
 
-    def set_uploader(self, requested_uploader):
+    def set_uploader(self, requested_uploader, keep=False):
         """Sets upload destination
 
         Args:
 
             requested_uploader (str): upload service. i.e. s3, scp
         """
-        self.up.set_uploader(requested_uploader)
+        self.up.set_uploader(requested_uploader, keep)
 
     def upload(self):
         "Uploads files in deploy folder"


### PR DESCRIPTION
set_uploader requires 3 parameters (self, requested_uploader, keep).  In core.py, the keep parameter is not being passed.
