### PR TITLE
Allow using custom dir as update_folder

### DIFF
--- a/pyupdater/client/__init__.py
+++ b/pyupdater/client/__init__.py
@@ -79,7 +79,7 @@ class Client(object):
 
     """
     def __init__(self, obj=None, refresh=False,
-                 progress_hooks=None, test=False):
+                 progress_hooks=None, test=False, data_dir=None):
         # String: Name of binary to update
         self.name = None
 
@@ -103,9 +103,9 @@ class Client(object):
 
         # Client config obj with settings to find & verify updates
         if obj is not None:
-            self.init_app(obj, refresh, test)
+            self.init_app(obj, refresh, test, data_dir)
 
-    def init_app(self, obj, refresh=False, test=False):
+    def init_app(self, obj, refresh=False, test=False, data_dir=None):
         """Sets up client with config values from obj
 
         ######Args:
@@ -145,9 +145,12 @@ class Client(object):
             self.data_dir = obj.DATA_DIR
             self.platform = 'mac'
         else:  # pragma: no cover
-            # Getting platform specific user data directory
-            self.data_dir = appdirs.user_data_dir(self.app_name,
-                                                  self.company_name)
+            if data_dir is None:
+                # Getting platform specific user data directory
+                self.data_dir = appdirs.user_data_dir(self.app_name,
+                                                      self.company_name)
+            else:
+                self.data_dir = data_dir
 
             # Used when parsing the update manifest
             self.platform = _get_system()

--- a/tests/data/update_repo_extract/app_extract_01.py
+++ b/tests/data/update_repo_extract/app_extract_01.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import os
 import sys
 
 from pyupdater.client import Client
@@ -26,7 +27,9 @@ def cb(status):
 def main():
     print(VERSION)
     client = Client(client_config.ClientConfig(),
-                    refresh=True, progress_hooks=[cb])
+                    refresh=True, progress_hooks=[cb],
+                    data_dir=os.path.join(
+                        os.path.dirname(sys.executable), '.update'))
     update = client.update_check(APPNAME, VERSION)
     if update is not None:
         success = update.download()


### PR DESCRIPTION
When creating portable application or the `appdirs.user_data_dir`
partition has limit free space, it's would be handy to have the
`update_folder` at the same folder as the app itself. This patch will
allow `pyupdater.client` to use a custom folder to hold update files
instead of always using `appdirs.user_data_dir`.