### PR TITLE
Use custom update folder

### DIFF
--- a/pyupdater/client/__init__.py
+++ b/pyupdater/client/__init__.py
@@ -79,7 +79,7 @@ class Client(object):
 
     """
     def __init__(self, obj=None, refresh=False,
-                 progress_hooks=None, test=False):
+                 progress_hooks=None, test=False, data_dir=None):
         # String: Name of binary to update
         self.name = None
 
@@ -103,9 +103,9 @@ class Client(object):
 
         # Client config obj with settings to find & verify updates
         if obj is not None:
-            self.init_app(obj, refresh, test)
+            self.init_app(obj, refresh, test, data_dir)
 
-    def init_app(self, obj, refresh=False, test=False):
+    def init_app(self, obj, refresh=False, test=False, data_dir=None):
         """Sets up client with config values from obj
 
         ######Args:
@@ -145,9 +145,12 @@ class Client(object):
             self.data_dir = obj.DATA_DIR
             self.platform = 'mac'
         else:  # pragma: no cover
-            # Getting platform specific user data directory
-            self.data_dir = appdirs.user_data_dir(self.app_name,
-                                                  self.company_name)
+            if data_dir is None:
+                # Getting platform specific user data directory
+                self.data_dir = appdirs.user_data_dir(self.app_name,
+                                                      self.company_name)
+            else:
+                self.data_dir = data_dir
 
             # Used when parsing the update manifest
             self.platform = _get_system()

--- a/tests/data/update_repo_extract/app_extract_01.py
+++ b/tests/data/update_repo_extract/app_extract_01.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import os
 import sys
 
 from pyupdater.client import Client
@@ -26,7 +27,9 @@ def cb(status):
 def main():
     print(VERSION)
     client = Client(client_config.ClientConfig(),
-                    refresh=True, progress_hooks=[cb])
+                    refresh=True, progress_hooks=[cb],
+                    data_dir=os.path.join(
+                        os.path.dirname(sys.executable), '.update'))
     update = client.update_check(APPNAME, VERSION)
     if update is not None:
         success = update.download()

--- a/tests/data/update_repo_extract/app_extract_01.py
+++ b/tests/data/update_repo_extract/app_extract_01.py
@@ -26,10 +26,13 @@ def cb(status):
 
 def main():
     print(VERSION)
-    client = Client(client_config.ClientConfig(),
+    data_dir= None
+    config = client_config.ClientConfig()
+    if getattr(config, 'USE_CUSTOM_DIR', False):
+        data_dir = os.path.join(os.path.dirname(sys.executable), '.update')
+    client = Client(config,
                     refresh=True, progress_hooks=[cb],
-                    data_dir=os.path.join(
-                        os.path.dirname(sys.executable), '.update'))
+                    data_dir=data_dir)
     update = client.update_check(APPNAME, VERSION)
     if update is not None:
         success = update.download()

--- a/tests/data/update_repo_extract/build_onefile_extract.py
+++ b/tests/data/update_repo_extract/build_onefile_extract.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import sys
 import tarfile
 import zipfile
@@ -14,6 +15,7 @@ home_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def build(app):
+    os.environ['PYINSTALLER_CONFIG_DIR'] = os.path.join(home_dir, '.cache')
     cmd = ('pyupdater build -F --clean --path={} '
            '--app-version={} {}'.format(home_dir, app[1], app[0]))
     os.system(cmd)
@@ -29,12 +31,20 @@ def extract(filename):
     archive.extractall()
 
 
-def main():
+def main(use_custom_dir, port):
     scripts = [('app_extract_01.py', '4.1'), ('app_extract_02.py', '4.2')]
 
     # We use this flag to untar & move our binary to the
     # current working directory
     first = True
+    # patch config_file for custom port number
+    config_file = open('client_config.py', 'rt').read()
+    config_file = re.sub(
+            'localhost:\d+', 'localhost:%s' % port, config_file)
+    # patch config_file for use_custom_dir
+    if use_custom_dir:
+        config_file += '\n    USE_CUSTOM_DIR = True\n'
+    open('client_config.py', 'wt').write(config_file)
     for s in scripts:
         build(s)
         if first:
@@ -66,4 +76,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    if len(sys.argv) != 3:
+        print('usage: %s <use_custom_dir> <port>' % sys.argv[0])
+    else:
+        main(sys.argv[1] == 'True', sys.argv[2])

--- a/tests/data/update_repo_restart/app_restart_01.py
+++ b/tests/data/update_repo_restart/app_restart_01.py
@@ -25,8 +25,12 @@ def cb(status):
 
 def main():
     print(VERSION)
-    client = Client(client_config.ClientConfig(),
-                    refresh=True, progress_hooks=[cb])
+    data_dir= None
+    config = client_config.ClientConfig()
+    if getattr(config, 'USE_CUSTOM_DIR', False):
+        data_dir = os.path.join(os.path.dirname(sys.executable), '.update')
+    client = Client(config,
+                    refresh=True, progress_hooks=[cb], data_dir=data_dir)
     update = client.update_check(APPNAME, VERSION)
     if update is not None:
         success = update.download()

--- a/tests/data/update_repo_restart/build_onefile_restart.py
+++ b/tests/data/update_repo_restart/build_onefile_restart.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import sys
 import tarfile
 import zipfile
@@ -14,6 +15,8 @@ home_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def build(app):
+    # Pyinstaller's --clean is not 'multiprocessing safe', let's use our own cache
+    os.environ['PYINSTALLER_CONFIG_DIR'] = os.path.join(home_dir, '.cache')
     cmd = ('pyupdater build -F --clean --path={} '
            '--app-version={} {}'.format(home_dir, app[1], app[0]))
     os.system(cmd)
@@ -29,12 +32,20 @@ def extract(filename):
     archive.extractall()
 
 
-def main():
+def main(use_custom_dir, port):
     scripts = [('app_restart_01.py', '4.1'), ('app_restart_02.py', '4.2')]
 
     # We use this flag to untar & move our binary to the
     # current working directory
     first = True
+    # patch config_file for custom port number
+    config_file = open('client_config.py', 'rt').read()
+    config_file = re.sub(
+            'localhost:\d+', 'localhost:%s' % port, config_file)
+    # patch config_file for use_custom_dir
+    if use_custom_dir:
+        config_file += '\n    USE_CUSTOM_DIR = True\n'
+    open('client_config.py', 'wt').write(config_file)
     for s in scripts:
         build(s)
         if first:
@@ -66,4 +77,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    if len(sys.argv) != 3:
+        print('usage: %s <use_custom_dir> <port>' % sys.argv[0])
+    else:
+        main(sys.argv[1] == 'True', sys.argv[2])

--- a/tests/test_pyupdater.py
+++ b/tests/test_pyupdater.py
@@ -29,6 +29,7 @@ import subprocess
 import os
 import sys
 import time
+import multiprocessing
 
 from dsdev_utils.paths import ChDir
 import pytest
@@ -40,6 +41,8 @@ from tconfig import TConfig
 AUTO_UPDATE_PAUSE = 25
 if sys.platform == 'win32':
     AUTO_UPDATE_PAUSE += 10
+
+UPDATE_LOCK = multiprocessing.Lock()
 
 
 @pytest.mark.usefixtures('cleandir', 'create_keypack', 'pyu')
@@ -61,16 +64,21 @@ class TestSetup(object):
 @pytest.mark.usefixtures('cleandir')
 class TestExecutionExtraction(object):
 
-    def test_execution_onefile_extract(self, datadir, simpleserver, pyu):
+    @pytest.mark.parametrize("custom_dir, port",
+                             [])
+                             # [(True, 8000),])
+                             # [(True, 8000), (False, 8001)])
+    def test_execution_onefile_extract(self, datadir, simpleserver, pyu,
+                                        custom_dir, port):
         data_dir = datadir['update_repo_extract']
         pyu.setup()
 
         # We are moving all of the files from the deploy directory to the
         # cwd. We will start a simple http server to use for updates
         with ChDir(data_dir):
-            simpleserver.start(8000)
+            simpleserver.start(port)
 
-            cmd = 'python build_onefile_extract.py'
+            cmd = 'python build_onefile_extract.py %s %s' % (custom_dir, port)
             os.system(cmd)
 
             # Moving all files from the deploy directory to the cwd
@@ -95,10 +103,18 @@ class TestExecutionExtraction(object):
             if sys.platform != 'win32':
                 app_name = './{}'.format(app_name)
 
-            # Call the binary to self update
-            subprocess.call(app_name, shell=True)
-            # Allow enough time for update process to complete.
-            time.sleep(AUTO_UPDATE_PAUSE)
+            if custom_dir:
+                # update with custom_dir is multiprocessing-safe
+                # create a dummy lock here to uniform the code
+                update_lock = multiprocessing.Lock()
+            else:
+                update_lock = UPDATE_LOCK
+
+            with update_lock:
+                # Call the binary to self update
+                subprocess.call(app_name, shell=True)
+                # Allow enough time for update process to complete.
+                time.sleep(AUTO_UPDATE_PAUSE)
 
             # Call again to check the output
             out = subprocess.check_output(app_name, shell=True)
@@ -112,16 +128,19 @@ class TestExecutionExtraction(object):
 @pytest.mark.usefixtures('cleandir')
 class TestExecutionRestart(object):
 
-    def test_execution_one_file_restart(self, datadir, simpleserver, pyu):
+    @pytest.mark.parametrize("custom_dir, port",
+                             [(True, 8002), (False, 8003)])
+    def test_execution_one_file_restart(self, datadir, simpleserver, pyu,
+                                        custom_dir, port):
         data_dir = datadir['update_repo_restart']
         pyu.setup()
 
         # We are moving all of the files from the deploy directory to the
         # cwd. We will start a simple http server to use for updates
         with ChDir(data_dir):
-            simpleserver.start(8001)
+            simpleserver.start(port)
 
-            cmd = 'python build_onefile_restart.py'
+            cmd = 'python build_onefile_restart.py %s %s' % (custom_dir, port)
             os.system(cmd)
 
             # Moving all files from the deploy directory to the cwd
@@ -146,10 +165,18 @@ class TestExecutionRestart(object):
             if sys.platform != 'win32':
                 app_name = './{}'.format(app_name)
 
-            # Call the binary to self update
-            subprocess.call(app_name)
-            # Allow enough time for update process to complete.
-            time.sleep(AUTO_UPDATE_PAUSE)
+            if custom_dir:
+                # update with custom_dir is multiprocessing-safe
+                # create a dummy lock here to uniform the code
+                update_lock = multiprocessing.Lock()
+            else:
+                update_lock = UPDATE_LOCK
+
+            with update_lock:
+                # Call the binary to self update
+                subprocess.call(app_name)
+                # Allow enough time for update process to complete.
+                time.sleep(AUTO_UPDATE_PAUSE)
 
             simpleserver.stop()
 


### PR DESCRIPTION
When creating portable application or the appdirs.user_data_dir
partition has limit free space, it's would be handy to have the
update_folder at the same folder as the app itself. This patch will
allow pyupdater.client to use a custom folder to hold update files
instead of always using appdirs.user_data_dir.

This PR also contains new unit test for testing new use cases.