### PR TITLE
Add attribute checks for some pyinstaller options that aren't always present and fix command detection in dispatch_command

### DIFF
--- a/pyupdater/cli/__init__.py
+++ b/pyupdater/cli/__init__.py
@@ -90,13 +90,13 @@ def _real_main(args, namespace_test_helper=None):  # pragma: no cover
 def dispatch_command(args, pyi_args=None, test=False):
     # Turns collect-debug-info into collect_debug_info
     cmd_str = "_cmd_" + args.command.replace('-', '_')
-    try:
+    if hasattr(commands, cmd_str):
         cmd = getattr(commands, cmd_str)
         # We are just making sure we can load the function
         if test:
             return True
         cmd(args, pyi_args)
-    except AttributeError:
+    else:
         # This should only get hit by misconfigured tests.
         # "Should" being the key word here :)
         log.error('Unknown Command: %s', cmd_str)

--- a/pyupdater/pyinstaller_compat.py
+++ b/pyupdater/pyinstaller_compat.py
@@ -88,7 +88,8 @@ def pyi_makespec(pyi_args):  # pragma: no cover
         # using noqa below so landscape.io will ignore it
         _pyi_makespec.__add_options(parser)  # noqa
         _pyi_log.__add_options(parser)  # noqa
-        _pyi_compat.__add_obsolete_options(parser)  # noqa
+        if hasattr(_pyi_compat, '__add_obsolete_options'):
+            _pyi_compat.__add_obsolete_options(parser)  # noqa
         # End hacking
         opts, args = parser.parse_args(pyi_args)
         # We are hacking into pyinstaller here & are aware of the risks
@@ -103,7 +104,8 @@ def pyi_makespec(pyi_args):  # pragma: no cover
         # using noqa below so landscape.io will ignore it
         _pyi_makespec.__add_options(parser)  # noqa
         _pyi_log.__add_options(parser)  # noqa
-        _pyi_compat.__add_obsolete_options(parser)  # noqa
+        if hasattr(_pyi_compat, '__add_obsolete_options'):
+            _pyi_compat.__add_obsolete_options(parser)  # noqa
         # End hacking
         parser.add_argument('scriptname', nargs='+')
 
@@ -112,7 +114,8 @@ def pyi_makespec(pyi_args):  # pragma: no cover
         # We call init because it loads logger into the global
         # namespace of the Pyinstaller.log module. logger is used
         # in the Pyinstaller.log.__process_options call
-        _pyi_log.init()
+        if hasattr(_pyi_log, 'init'):
+            _pyi_log.init()
         # We are hacking into pyinstaller here & are aware of the risks
         # using noqa below so landscape.io will ignore it
         _pyi_log.__process_options(parser, args)  # noqa


### PR DESCRIPTION
This should resolve [this](https://github.com/JMSwag/PyUpdater/issues/66) issue. The `Unknown Command: _cmd_build` error is incorrect/misleading because the attribute error caught by `except AttributeError:` was emitted due to `__add_obsolete_options` being no longer present in pyinstaller and not due to `_cmd_build` actually being missing.