### PR TITLE
Fix pytest-datadir bug

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 
 deps =
     pytest
-    pytest-datadir
+    pytest-datadir==0.2.0
     pytest-cov
     pytest-xdist
     pytest-remove-stale-bytecode


### PR DESCRIPTION
Seems there were some breaking changes to this dependency recently, I've locked it to a working commit.