### PR TITLE
Develop

### DIFF
--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -167,14 +167,14 @@ class Restarter(object):
 
     def _win_overwrite(self):
         isFolder = os.path.isdir(self.updated_app)
-        with io.open(self.bat_file, 'w', encoding='utf-8') as bat:
+        with io.open(self.bat_file, 'w') as bat:
             if isFolder:
                 bat.write("""
 @echo off
 echo Updating to latest version...
 ping 127.0.0.1 -n 5 -w 1000 > NUL
 robocopy "{}" "{}" /e /move /V /PURGE > NUL
-DEL {}
+DEL "{}"
 DEL "%~f0"
 """.format(self.updated_app, self.current_app, self.vbs_file))
             else:
@@ -183,11 +183,11 @@ DEL "%~f0"
 echo Updating to latest version...
 ping 127.0.0.1 -n 5 -w 1000 > NUL
 move /Y "{}" "{}" > NUL
-DEL {}
+DEL "{}"
 DEL "%~f0"
 """.format(self.updated_app, self.current_app, self.vbs_file))
 
-        with io.open(self.vbs_file, 'w', encoding='utf-8') as vbs:
+        with io.open(self.vbs_file, 'w') as vbs:
             # http://www.howtogeek.com/131597/can-i-run-a-windows-batch-
             # file-without-a-visible-command-prompt/
             vbs.write('CreateObject("Wscript.Shell").Run """" '
@@ -199,7 +199,7 @@ DEL "%~f0"
 
     def _win_overwrite_restart(self):
         isFolder = os.path.isdir(self.updated_app)
-        with io.open(self.bat_file, 'w', encoding='utf-8') as bat:
+        with io.open(self.bat_file, 'w') as bat:
             if isFolder:
                 bat.write("""
 @echo off
@@ -208,7 +208,7 @@ ping 127.0.0.1 -n 5 -w 1000 > NUL
 robocopy "{}" "{}" /e /move /V > NUL
 echo restarting...
 start "" "{}"
-DEL {}
+DEL "{}"
 DEL "%~f0"
 """.format(self.updated_app, self.current_app,
                     os.path.join(self.current_app,
@@ -222,11 +222,11 @@ ping 127.0.0.1 -n 5 -w 1000 > NUL
 move /Y "{}" "{}" > NUL
 echo restarting...
 start "" "{}"
-DEL {}
+DEL "{}"
 DEL "%~f0"
 """.format(self.updated_app, self.current_app,
                     self.current_app, self.vbs_file))
-        with io.open(self.vbs_file, 'w', encoding='utf-8') as vbs:
+        with io.open(self.vbs_file, 'w') as vbs:
             # http://www.howtogeek.com/131597/can-i-run-a-windows-batch-
             # file-without-a-visible-command-prompt/
             vbs.write('CreateObject("Wscript.Shell").Run """" '


### PR DESCRIPTION
When use pyupdater in windows of chinese version, if program file in path which has chinese char, update will failed. because the cmd.exe use gbk encode,but pyupdate write update.bat in utf8 encode. So change encode to system default when write update.bat,fix the bug.
