### PR TITLE
fix to wrong directory remove on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,21 @@ python:
 env: # important! Read the docs!! https://docs.travis-ci.com/user/customizing-the-build#Rows-that-are-Allowed-to-Fail
 
 matrix:
-
+  fast_finish: true
   allow_failures:
     - python: "nightly"
-
+  include:
+    - os: osx
+      language: generic
+      python: "3.6"
+      install:
+        - brew update
+        - brew install python3
+        - python3 -m venv venv
+        - source venv/bin/activate
+        - pip3 install tox-travis
+      script: tox
+  
 install:
   - pip install tox-travis filelock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - python3 -m venv venv
         - source venv/bin/activate
         - pip3 install tox-travis
-      script: tox
+      script: "tox -vv"
   
 install:
   - pip install tox-travis filelock codecov coverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ install:
 
     # Create .whl packages from dependencies for possible caching.
     # First install 'wheel' package to be able create .whl files.
-    - "build.cmd pip install wheel tox filelock"
+    - "build.cmd pip install wheel tox filelock codecov"
 
     # Create c:/wheels if it does not exist.
     - ps: If ( -not (Test-Path C:/wheels) )  { mkdir C:/wheels }
@@ -97,3 +97,6 @@ on_finish:
 test_script:
     # Split tests into several subprocesses.
     - "build.cmd tox"
+
+after_test:
+  - "build.cmd codecov"

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -648,7 +648,6 @@ class AppUpdate(LibUpdate):
         if get_system() == 'mac':
             if self._current_app_dir.endswith('MacOS') is True:
                 log.debug('Looks like we\'re dealing with a Mac Gui')
-
                 temp_dir = get_mac_dot_app_dir(self._current_app_dir)
                 self._current_app_dir = temp_dir
 
@@ -673,7 +672,10 @@ class AppUpdate(LibUpdate):
         # update to new location
         # if update_app is a directory, then we are updating a directory
         if os.path.isdir(app_update):
-            shutil.rmtree(os.path.dirname(current_app))
+            if (os.path.isdir(current_app)):
+                shutil.rmtree(current_app)
+            else:
+                shutil.rmtree(os.path.dirname(current_app))
 
         if os.path.exists(current_app):
             remove_any(current_app)

--- a/tests/data/update_repo_extract/app_extract_01.py
+++ b/tests/data/update_repo_extract/app_extract_01.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from pyupdater.client import Client
+from dsdev_utils.paths import get_mac_dot_app_dir
 
 import client_config
 
@@ -29,7 +30,13 @@ def main():
     data_dir = None
     config = client_config.ClientConfig()
     if getattr(config, 'USE_CUSTOM_DIR', False):
-        data_dir = os.path.join(os.path.dirname(sys.executable), '.update')
+        if (sys.platform == 'darwin' and os.path.dirname(sys.executable
+                                                         ).endswith('MacOS')):
+            data_dir = os.path.join(get_mac_dot_app_dir(os.path.dirname(
+                sys.executable)), '.update')
+        else:
+            data_dir = os.path.join(os.path.dirname(os.path.dirname(
+                sys.executable)), '.update')
     client = Client(config,
                     refresh=True, progress_hooks=[cb],
                     data_dir=data_dir)

--- a/tests/data/update_repo_extract/app_extract_onedir.py
+++ b/tests/data/update_repo_extract/app_extract_onedir.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from pyupdater.client import Client
+from dsdev_utils.paths import get_mac_dot_app_dir
 
 import client_config
 
@@ -29,8 +30,13 @@ def main():
     data_dir = None
     config = client_config.ClientConfig()
     if getattr(config, 'USE_CUSTOM_DIR', False):
-        data_dir = os.path.join(os.path.dirname(
-            os.path.dirname(sys.executable)), '.update')
+        if (sys.platform == 'darwin' and os.path.dirname(sys.executable
+                                                         ).endswith('MacOS')):
+            data_dir = os.path.join(get_mac_dot_app_dir(
+                os.path.dirname(sys.executable)), '.update')
+        else:
+            data_dir = os.path.join(os.path.dirname(os.path.dirname(
+                sys.executable)), '.update')
     client = Client(config,
                     refresh=True, progress_hooks=[cb],
                     data_dir=data_dir)

--- a/tests/data/update_repo_extract/build_onedir_extract.py
+++ b/tests/data/update_repo_extract/build_onedir_extract.py
@@ -16,8 +16,8 @@ home_dir = os.path.dirname(os.path.abspath(__file__))
 
 def build(app):
     os.environ['PYINSTALLER_CONFIG_DIR'] = os.path.join(home_dir, '.cache')
-    cmd = ('pyupdater build -D --clean --path={} '
-           '--app-version={} {}'.format(home_dir, app[1], app[0]))
+    cmd = ('pyupdater build -D --clean {} --path={} '
+           '--app-version={} {}'.format(app[2], home_dir, app[1], app[0]))
     os.system(cmd)
 
 
@@ -31,8 +31,11 @@ def extract(filename):
     archive.extractall()
 
 
-def main(use_custom_dir, port):
-    scripts = [('app_extract_onedir.py', '4.1'), ('app_extract_02.py', '4.2')]
+def main(use_custom_dir, port, windowed):
+    scripts = [('app_extract_onedir.py', '4.1',
+                '--windowed' if windowed else ''),
+               ('app_extract_02.py', '4.2',
+                '--windowed' if windowed else '')]
 
     # We use this flag to untar & move our binary to the
     # current working directory
@@ -77,7 +80,7 @@ def main(use_custom_dir, port):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print('usage: %s <use_custom_dir> <port>' % sys.argv[0])
+    if len(sys.argv) != 4:
+        print('usage: %s <use_custom_dir> <port> <windowed>' % sys.argv[0])
     else:
-        main(sys.argv[1] == 'True', sys.argv[2])
+        main(sys.argv[1] == 'True', sys.argv[2], sys.argv[3] == 'True')

--- a/tests/data/update_repo_extract/build_onefile_extract.py
+++ b/tests/data/update_repo_extract/build_onefile_extract.py
@@ -16,8 +16,8 @@ home_dir = os.path.dirname(os.path.abspath(__file__))
 
 def build(app):
     os.environ['PYINSTALLER_CONFIG_DIR'] = os.path.join(home_dir, '.cache')
-    cmd = ('pyupdater build -F --clean --path={} '
-           '--app-version={} {}'.format(home_dir, app[1], app[0]))
+    cmd = ('pyupdater build -F {} --clean --path={} '
+           '--app-version={} {}'.format(app[2], home_dir, app[1], app[0]))
     os.system(cmd)
 
 
@@ -31,8 +31,11 @@ def extract(filename):
     archive.extractall()
 
 
-def main(use_custom_dir, port):
-    scripts = [('app_extract_01.py', '4.1'), ('app_extract_02.py', '4.2')]
+def main(use_custom_dir, port, windowed):
+    scripts = [('app_extract_01.py', '4.1',
+                '--windowed' if windowed else ''),
+               ('app_extract_02.py', '4.2',
+                '--windowed' if windowed else '')]
 
     # We use this flag to untar & move our binary to the
     # current working directory
@@ -77,7 +80,7 @@ def main(use_custom_dir, port):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print('usage: %s <use_custom_dir> <port>' % sys.argv[0])
+    if len(sys.argv) != 4:
+        print('usage: %s <use_custom_dir> <port> <windowed>' % sys.argv[0])
     else:
-        main(sys.argv[1] == 'True', sys.argv[2])
+        main(sys.argv[1] == 'True', sys.argv[2], sys.argv[3] == 'True')

--- a/tests/data/update_repo_restart/app_restart_01.py
+++ b/tests/data/update_repo_restart/app_restart_01.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from pyupdater.client import Client
+from dsdev_utils.paths import get_mac_dot_app_dir
 
 import client_config
 
@@ -30,7 +31,12 @@ def main():
     config = client_config.ClientConfig()
     if getattr(config, 'USE_CUSTOM_DIR', False):
         print("Using custom directory")
-        data_dir = os.path.join(os.path.dirname(sys.executable), '.update')
+        if (sys.platform == 'darwin' and os.path.dirname(sys.executable
+                                                         ).endswith('MacOS')):
+            data_dir = os.path.join(get_mac_dot_app_dir(os.path.dirname(
+                sys.executable)), '.update')
+        else:
+            data_dir = os.path.join(os.path.dirname(sys.executable), '.update')
     client = Client(config, refresh=True,
                     progress_hooks=[cb], data_dir=data_dir)
     update = client.update_check(APPNAME, VERSION)

--- a/tests/data/update_repo_restart/app_restart_onedir.py
+++ b/tests/data/update_repo_restart/app_restart_onedir.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from pyupdater.client import Client
+from dsdev_utils.paths import get_mac_dot_app_dir
 
 import client_config
 
@@ -30,8 +31,13 @@ def main():
     config = client_config.ClientConfig()
     if getattr(config, 'USE_CUSTOM_DIR', False):
         print("Using custom directory")
-        data_dir = os.path.join(os.path.dirname(
-            os.path.dirname(sys.executable)), '.update')
+        if (sys.platform == 'darwin' and os.path.dirname(sys.executable
+                                                         ).endswith('MacOS')):
+            data_dir = os.path.join(get_mac_dot_app_dir(os.path.dirname(
+                sys.executable)), '.update')
+        else:
+            data_dir = os.path.join(os.path.dirname(os.path.dirname(
+                sys.executable)), '.update')
     client = Client(config, refresh=True,
                     progress_hooks=[cb], data_dir=data_dir)
     update = client.update_check(APPNAME, VERSION)

--- a/tests/data/update_repo_restart/build_onedir_restart.py
+++ b/tests/data/update_repo_restart/build_onedir_restart.py
@@ -7,6 +7,7 @@ import zipfile
 
 from dsdev_utils.system import get_system
 
+
 log = logging.getLogger()
 
 cmd1 = 'pyupdater pkg -P'
@@ -18,8 +19,8 @@ def build(app):
     # Pyinstaller's --clean is not 'multiprocessing safe',
     # let's use our own cache
     os.environ['PYINSTALLER_CONFIG_DIR'] = os.path.join(home_dir, '.cache')
-    cmd = ('pyupdater build -D --clean --path={} '
-           '--app-version={} {}'.format(home_dir, app[1], app[0]))
+    cmd = ('pyupdater build -D {} --clean --path={} '
+           '--app-version={} {}'.format(app[2], home_dir, app[1], app[0]))
     os.system(cmd)
 
 
@@ -33,8 +34,11 @@ def extract(filename):
     archive.extractall()
 
 
-def main(use_custom_dir, port):
-    scripts = [('app_restart_onedir.py', '4.1'), ('app_restart_02.py', '4.2')]
+def main(use_custom_dir, port, windowed):
+    scripts = [('app_restart_onedir.py', '4.1',
+                '--windowed' if windowed else ''),
+               ('app_restart_02.py', '4.2',
+                '--windowed' if windowed else '')]
 
     # We use this flag to untar & move our binary to the
     # current working directory
@@ -79,7 +83,7 @@ def main(use_custom_dir, port):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print('usage: %s <use_custom_dir> <port>' % sys.argv[0])
+    if len(sys.argv) != 4:
+        print('usage: %s <use_custom_dir> <port> <windowed>' % sys.argv[0])
     else:
-        main(sys.argv[1] == 'True', sys.argv[2])
+        main(sys.argv[1] == 'True', sys.argv[2], sys.argv[3] == 'True')

--- a/tests/data/update_repo_restart/build_onefile_restart.py
+++ b/tests/data/update_repo_restart/build_onefile_restart.py
@@ -18,8 +18,8 @@ def build(app):
     # Pyinstaller's --clean is not 'multiprocessing safe',
     # let's use our own cache
     os.environ['PYINSTALLER_CONFIG_DIR'] = os.path.join(home_dir, '.cache')
-    cmd = ('pyupdater build -F --clean --path={} '
-           '--app-version={} {}'.format(home_dir, app[1], app[0]))
+    cmd = ('pyupdater build -F {} --clean --path={} '
+           '--app-version={} {}'.format(app[2], home_dir, app[1], app[0]))
     os.system(cmd)
 
 
@@ -33,8 +33,11 @@ def extract(filename):
     archive.extractall()
 
 
-def main(use_custom_dir, port):
-    scripts = [('app_restart_01.py', '4.1'), ('app_restart_02.py', '4.2')]
+def main(use_custom_dir, port, windowed):
+    scripts = [('app_restart_01.py', '4.1',
+                '--windowed' if windowed else ''),
+               ('app_restart_02.py', '4.2',
+                '--windowed' if windowed else '')]
 
     # We use this flag to untar & move our binary to the
     # current working directory
@@ -79,7 +82,7 @@ def main(use_custom_dir, port):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print('usage: %s <use_custom_dir> <port>' % sys.argv[0])
+    if len(sys.argv) != 4:
+        print('usage: %s <use_custom_dir> <port> <windowed>' % sys.argv[0])
     else:
-        main(sys.argv[1] == 'True', sys.argv[2])
+        main(sys.argv[1] == 'True', sys.argv[2], sys.argv[3] == 'True')

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ toxworkdir=/tmp/tox
 [testenv]
 setenv = TOX_ENV_NAME={envname}
 sitepackages = True
-commands = py.test tests --cov=./
+commands = py.test tests --cov=pyupdater
 
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist=py27,py36
 toxworkdir=/tmp/tox
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ toxworkdir=/tmp/tox
 [testenv]
 setenv = TOX_ENV_NAME={envname}
 sitepackages = True
-
-commands = py.test tests
+deps = codecov>=1.4.0
+commands = py.test tests --cov=./
 
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ toxworkdir=/tmp/tox
 [testenv]
 setenv = TOX_ENV_NAME={envname}
 sitepackages = True
-deps = codecov>=1.4.0
 commands = py.test tests --cov=./
 
 deps =
@@ -15,6 +14,7 @@ deps =
     pytest-xdist
     pytest-remove-stale-bytecode
     tox-pyenv
+    codecov>=1.4.0
     filelock
     -rrequirements.txt
     --upgrade

--- a/tox.ini
+++ b/tox.ini
@@ -32,3 +32,4 @@ addopts =
     --cov
     --cov-config .coveragerc
     --cov-report xml
+    --cov {envsitepackagesdir}/pyupdater


### PR DESCRIPTION
this is the fix for #91 and workarround for #92 , it was necessary to add a windowed mode test to find the root of the bug on OSX. also added the travis OSX support as mentioned by @cbenhagen in #92 , but it fails because there's not a python 3.4 and 3.5 version for osx, so i ended removing those.

i'm not fluent on tox or travis, so any advice regarding the osx support is welcome.