### PR TITLE
Fix to OSX tests on travis-CI and repair to appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,27 +9,33 @@ python:
   - "3.6"
   - "nightly"
 
-env: # important! Read the docs!! https://docs.travis-ci.com/user/customizing-the-build#Rows-that-are-Allowed-to-Fail
-
 matrix:
   fast_finish: true
   allow_failures:
     - python: "nightly"
   include:
-    - os: osx
-      language: generic
-      python: "3.6"
-      install:
-        - brew update
-        - brew install python3
-        - python3 -m venv venv
-        - source venv/bin/activate
-        - pip3 install tox-travis
-      script: "tox -vv"
-  
+  - os: osx
+    language: generic
+    python: "3.6"
+    env: "TOXENV=py36"
+    install:
+      - brew update
+      - brew install python3
+      - python3 -m venv venv
+      - source venv/bin/activate
+      - pip3 install tox-travis filelock codecov coverage
+    script: tox
+  - os: osx
+    language: generic
+    python: "2.7"
+    env: "TOXENV=py27"
+    install:
+      - pip install tox-travis filelock codecov coverage
+    script: tox 
+
+
 install:
   - pip install tox-travis filelock codecov coverage
-
 script: tox
 after_success: codecov
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,7 @@ install:
     # available on PyPI.
     # TODO: remove out-of-date wheels to avoid overflowing the build cache
     - "build.cmd pip wheel --use-wheel --wheel-dir C:/wheels --find-links c:/wheels -r requirements.txt"
-    - "build.cmd pip wheel --use-wheel --wheel-dir C:/wheels --find-links c:/wheels -r dev/requirements.txt"
+    - 
 #
 build: none
 


### PR DESCRIPTION
well.... looks line a single line was enough to don't run any OSX test on travis-ci. this PR solves it. also removed one line from appveyor.yml and now dev/requirements.txt is not longer installed during the test, i removed it, cuz it was making windows tests fail.