### PR TITLE
Pinned pip at 9.0.3, prior to --use-wheels flag being removed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
 
     # Upgrade to the latest version of pip to avoid it displaying warnings
     # about it being out of date.
-    - "build.cmd %PYTHON%\\python.exe -m pip install -U pip"
+    - "build.cmd %PYTHON%\\python.exe -m pip install -U pip==9.0.3"
 
     # Create .whl packages from dependencies for possible caching.
     # First install 'wheel' package to be able create .whl files.
@@ -78,7 +78,7 @@ install:
     # available on PyPI.
     # TODO: remove out-of-date wheels to avoid overflowing the build cache
     - "build.cmd pip wheel --use-wheel --wheel-dir C:/wheels --find-links c:/wheels -r requirements.txt"
-    - 
+    -
 #
 build: none
 


### PR DESCRIPTION
Appveyor test are currently failing, I believe due to a new version of `pip` that deprecates a bunch of flags.

https://github.com/pypa/pip/blob/3a6b3995c141c0888af6591a59240ba5db7d9914/NEWS.rst#deprecations-and-removals