### PR TITLE
async keyword Python 3.7

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -201,7 +201,7 @@ Downloads update
 
 ######Args:
 
-    async (bool): Perform download in background thread
+    async_download (bool): Perform download in background thread
 
 ##### LibUpdate.extract()
 

--- a/docs/usage-cli-advanced.md
+++ b/docs/usage-cli-advanced.md
@@ -38,7 +38,7 @@ Example of async download:
 ```
 app_update = client.update_check(APP_NAME, APP_VERSION)
 if app_update:
-    app_update.download(async=True)
+    app_update.download(async_download=True)
 
 # To check the status of the download
 # Returns a boolean

--- a/docs/usage-client-asset.md
+++ b/docs/usage-client-asset.md
@@ -62,7 +62,7 @@ if lib_update is not None:
 ####We can also download in a background thread.
 ```
 if lib_update is not None:
-    lib_update.download(async=True)
+    lib_update.download(async_download=True)
 ```
 
 ###Step 6a - Extract

--- a/docs/usage-client.md
+++ b/docs/usage-client.md
@@ -62,7 +62,7 @@ if app_update is not None:
 ####We can also download in a background thread.
 ```
 if app_update is not None:
-    app_update.download(async=True)
+    app_update.download(async_download=True)
 ```
 
 ###Step 6a - Overwrite

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -368,14 +368,14 @@ class LibUpdate(object):
             return False
         return self._is_downloaded()
 
-    def download(self, async=False):
+    def download(self, async_download=False):
         """Downloads update
 
         ######Args:
 
-            async (bool): Perform download in background thread
+            async_download (bool): Perform download in background thread
         """
-        if async is True:
+        if async_download is True:
             if self._is_downloading is False:
                 self._is_downloading = True
                 threading.Thread(target=self._download).start()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -166,7 +166,7 @@ class TestDownload(object):
         update = client.update_check(client.app_name, '0.0.1')
         assert update is not None
         assert update.app_name == 'Acme'
-        update.download(async=True)
+        update.download(async_download=True)
         count = 0
         while count < 61:
             if update.is_downloaded() is True:
@@ -183,9 +183,9 @@ class TestDownload(object):
         update = client.update_check(client.app_name, '0.0.1')
         assert update is not None
         assert update.app_name == 'Acme'
-        update.download(async=True)
+        update.download(async_download=True)
         count = 0
-        assert update.download(async=True) is None
+        assert update.download(async_download=True) is None
         assert update.download() is None
         while count < 61:
             if update.is_downloaded() is True:


### PR DESCRIPTION
In Python 3.7 `async` is `reserved keyword`.
Solution: renamed `async` bool with `async_download`,