### PR TITLE
added DOWNLOAD_TIMEOUT in ClientConfig

### DIFF
--- a/pyupdater/client/__init__.py
+++ b/pyupdater/client/__init__.py
@@ -191,6 +191,9 @@ class Client(object):
         # Max number of download retries
         self.max_download_retries = config.get('MAX_DOWNLOAD_RETRIES')
 
+        # Download timeout
+        self.download_timeout = config.get('DOWNLOAD_TIMEOUT', 30)
+
         # The name of the version file to download
         self.version_file = settings.VERSION_FILE_FILENAME
 
@@ -308,6 +311,7 @@ class Client(object):
             'max_download_retries': self.max_download_retries,
             'progress_hooks': list(set(self.progress_hooks)),
             'urllib3_headers': self.urllib3_headers,
+            'download_timeout': self.download_timeout,
         }
 
         # Return update object with which handles downloading,

--- a/pyupdater/client/downloader.py
+++ b/pyupdater/client/downloader.py
@@ -123,6 +123,9 @@ class FileDownloader(object):
         # Max attempts to download resource
         self.max_download_retries = kwargs.get('max_download_retries')
 
+        # Download timeout
+        self.download_timeout = kwargs.get('download_timeout')
+
         # Progress hooks to be called
         self.progress_hooks = kwargs.get('progress_hooks', [])
 
@@ -357,6 +360,7 @@ class FileDownloader(object):
     def _create_response(self):
         data = None
         max_download_retries = self.max_download_retries
+        download_timeout = self.download_timeout
         for url in self.urls:
 
             # Create url for resource
@@ -365,7 +369,8 @@ class FileDownloader(object):
             try:
                 data = self.http_pool.urlopen('GET', file_url,
                                               preload_content=False,
-                                              retries=max_download_retries)
+                                              retries=max_download_retries,
+                                              timeout=download_timeout)
             except urllib3.exceptions.SSLError:
                 log.debug('SSL cert not verified')
                 continue

--- a/pyupdater/client/patcher.py
+++ b/pyupdater/client/patcher.py
@@ -81,6 +81,7 @@ class Patcher(object):
         self.update_urls = kwargs.get('update_urls', [])
         self.verify = kwargs.get('verify', True)
         self.max_download_retries = kwargs.get('max_download_retries')
+        self.download_timeout = kwargs.get('download_timeout')
         self.urllib3_headers = kwargs.get('urllib3_headers')
 
         # Progress hooks to be called
@@ -292,7 +293,8 @@ class Patcher(object):
             fd = FileDownloader(p['patch_name'], p['patch_urls'],
                                 hexdigest=p['patch_hash'], verify=self.verify,
                                 max_download_retries=self.max_download_retries,
-                                urllb3_headers=self.urllib3_headers)
+                                urllb3_headers=self.urllib3_headers,
+                                download_timeout=self.download_timeout)
 
             # Attempt to download resource
             data = fd.download_verify_return()

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -324,6 +324,9 @@ class LibUpdate(object):
         # The amount of times to retry a url before giving up
         self.max_download_retries = data.get('max_download_retries')
 
+        # Download timeout
+        self.download_timeout = data.get("download_timeout")
+
         # The latest version available
         self.latest = _get_highest_version(self.name, self.platform,
                                            self.channel, self.easy_data,
@@ -563,7 +566,8 @@ class LibUpdate(object):
                                 hexdigest=file_hash, verify=self.verify,
                                 progress_hooks=self.progress_hooks,
                                 max_download_retries=self.max_download_retries,
-                                urllb3_headers=self.urllib3_headers)
+                                urllb3_headers=self.urllib3_headers,
+                                download_timeout=self.download_timeout)
             result = fd.download_verify_write()
             if result:
                 log.debug('Download Complete')


### PR DESCRIPTION
Avoid hanging on download update through adding DOWNLOAD_TIMEOUT in ClientConfig, default value is 30