### PR TITLE
issue-205: Change to named logger as to to not clash with other loggers

### DIFF
--- a/pyupdater/__init__.py
+++ b/pyupdater/__init__.py
@@ -35,7 +35,7 @@ from pyupdater.core import PyUpdater
 __all__ = ["PyUpdater"]
 
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 # Console logger


### PR DESCRIPTION
To fix issue #205 
Environment
```
Ubuntu 18.04
Python 2.7.15rc1
altgraph==0.16.1
appdirs==1.4.3
bsdiff4==1.1.5
certifi==2019.3.9
chardet==3.0.4
dis3==0.1.3
docutils==0.14
dsdev-utils==1.0.4
ed25519==1.5
future==0.17.1
idna==2.8
Kivy==1.10.1
Kivy-Garden==0.1.4
macholib==1.11
pbr==5.2.1
pefile==2019.4.18
Pygments==2.4.2
PyInstaller==3.4
PyUpdater==3.0.1+57.g1b9abf3
requests==2.22.0
six==1.12.0
stevedore==1.30.1
urllib3==1.25.3
```
Test app
```
import os
from kivy.logger import Logger
from kivy.config import Config
import kivy

Config.set('kivy', 'log_dir', os.getcwd())
Config.set('kivy', 'log_level', 'trace')

from kivy.app import App
from kivy.uix.label import Label

import pyupdater

class MyApp(App):

    def build(self):
        Logger.debug('Here we go!')
        return Label(text='hi there')


if __name__ == '__main__':
    MyApp().run()
```