### PR TITLE
Support generic headers and HTTP timeouts

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -95,7 +95,7 @@ progress_hooks (list): List of callbacks
 
 data_dir (str): Path to custom update folder
 
-headers (dict): A urllib3.utils.make_headers compatible dictionary
+headers (dict): A dictionary of generic and/or urllib3.utils.make_headers compatible headers
 
 test (bool): Used to initialize a test client
 

--- a/pyupdater/client/__init__.py
+++ b/pyupdater/client/__init__.py
@@ -85,7 +85,7 @@ class Client(object):
 
     data_dir (str): Path to custom update folder
 
-    headers (dict): A urllib3.utils.make_headers compatible dictionary
+    headers (dict): A dictionary of generic and/or urllib3.utils.make_headers compatible headers
 
     test (bool): Used to initialize a test client
 
@@ -129,8 +129,6 @@ class Client(object):
             if not isinstance(progress_hooks, list):
                 raise SyntaxError("progress_hooks must be provided as a list.")
             self.progress_hooks += progress_hooks
-
-        obj.URLLIB3_HEADERS = headers
 
         # A super dict used to save config info & be dot accessed
         config = _Config()
@@ -198,8 +196,8 @@ class Client(object):
         # The name of the key file to download
         self.key_file = settings.KEY_FILE_FILENAME
 
-        # urllib3 headers
-        self.urllib3_headers = obj.URLLIB3_HEADERS
+        # headers
+        self.headers = headers
 
         # Creating data & update directories
         self._setup()
@@ -244,7 +242,7 @@ class Client(object):
             "http_timeout": self.http_timeout,
             "max_download_retries": self.max_download_retries,
             "progress_hooks": self.progress_hooks,
-            "urllib3_headers": self.urllib3_headers,
+            "headers": self.headers,
             "verify": self.verify,
         }
 
@@ -317,7 +315,7 @@ class Client(object):
             "verify": self.verify,
             "max_download_retries": self.max_download_retries,
             "progress_hooks": list(set(self.progress_hooks)),
-            "urllib3_headers": self.urllib3_headers,
+            "headers": self.headers,
             "downloader": self.downloader,
         }
 
@@ -436,7 +434,8 @@ class Client(object):
                         vf,
                         self.update_urls,
                         verify=self.verify,
-                        urllb3_headers=self.urllib3_headers,
+                        headers=self.headers,
+                        http_timeout=self.http_timeout
                     )
                 data = fd.download_verify_return()
                 try:
@@ -468,7 +467,8 @@ class Client(object):
                     self.key_file,
                     self.update_urls,
                     verify=self.verify,
-                    urllb3_headers=self.urllib3_headers,
+                    headers=self.headers,
+                    http_timeout=self.http_timeout
                 )
             data = fd.download_verify_return()
             try:

--- a/pyupdater/client/patcher.py
+++ b/pyupdater/client/patcher.py
@@ -67,7 +67,9 @@ class Patcher(object):
 
         max_download_retries (int): Number of times to retry a download
 
-        urllib3_headers (dict): Headers to be used with http request
+        headers (dict): Headers to be used with http request.  Accepts urllib3 and generic headers.
+
+        http_timeout (int): HTTP timeout or None
     """
 
     def __init__(self, **kwargs):
@@ -81,8 +83,9 @@ class Patcher(object):
         self.update_urls = kwargs.get("update_urls", [])
         self.verify = kwargs.get("verify", True)
         self.max_download_retries = kwargs.get("max_download_retries")
-        self.urllib3_headers = kwargs.get("urllib3_headers")
+        self.headers = kwargs.get("headers")
         self.downloader = kwargs.get("downloader")
+        self.http_timeout = kwargs.get("http_timeout")
 
         # Progress hooks to be called
         self.progress_hooks = kwargs.get("progress_hooks", [])
@@ -302,7 +305,8 @@ class Patcher(object):
                         hexdigest=p["patch_hash"],
                         verify=self.verify,
                         max_download_retries=self.max_download_retries,
-                        urllb3_headers=self.urllib3_headers,
+                        headers=self.headers,
+                        http_timeout=self.http_timeout
                     )
 
                 # Attempt to download resource

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -418,8 +418,8 @@ class LibUpdate(object):
         # Weather or not the verify the https connection
         self.verify = data.get("verify", True)
 
-        # Extra headers to pass to urllib3
-        self.urllib3_headers = data.get("urllib3_headers")
+        # Extra headers
+        self.headers = data.get("headers")
 
         # The amount of times to retry a url before giving up
         self.max_download_retries = data.get("max_download_retries")
@@ -684,7 +684,8 @@ class LibUpdate(object):
                     verify=self.verify,
                     progress_hooks=self.progress_hooks,
                     max_download_retries=self.max_download_retries,
-                    urllb3_headers=self.urllib3_headers,
+                    headers=self.headers,
+                    http_timeout=self.http_timeout
                 )
             result = fd.download_verify_write()
             if result:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -63,10 +63,20 @@ class TestData(object):
 
 
 @pytest.mark.usefixtue("cleandir")
-class TestBasicAuth(object):
+class TestBasicAuthUrlLib(object):
     def test_basic_auth(self):
         headers = {"basic_auth": "user:pass"}
-        fd = FileDownloader("test", ["test"], urllb3_headers=headers)
+        fd = FileDownloader("test", ["test"], headers=headers)
+        http = fd._get_http_pool(secure=True)
+        sc = http.request("GET", "https://httpbin.org/basic-auth/user/pass").status
+        assert sc == 200
+
+
+@pytest.mark.usefixtue("cleandir")
+class TestAuthorizationHeader(object):
+    def test_auth_header(self):
+        headers = {"Authorization": "Basic dXNlcjpwYXNz"}
+        fd = FileDownloader("test", ["test"], headers=headers)
         http = fd._get_http_pool(secure=True)
         sc = http.request("GET", "https://httpbin.org/basic-auth/user/pass").status
         assert sc == 200


### PR DESCRIPTION
Instead of solely `urllib3.utils.make_headers` compatible headers, there is now the ability to pass generic headers, such as "Authorization."  For example, the following is now valid headers argument when creating a `Client`:
```
headers={
    "accept_encoding": "gzip",  # Parsed by urllib3.utils.make_headers to "Accept-Encoding"
    "Authorization": "Bearer " + str(access_token) # Not parsed by urllib3
}
```
Furthermore, http timeouts are honored in the FileDownloader.

Fixes #218 and implements #219.