### PR TITLE
Add additional update strategy based on renaming

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -97,6 +97,14 @@ data_dir (str): Path to custom update folder
 
 headers (dict): A dictionary of generic and/or urllib3.utils.make_headers compatible headers
 
+strategy (str): The update strategy to use.  By default, the overwrite
+strategy is used.  Accepts any of `UpdateStrategy.DEFAULT`,
+`UpdateStrategy.OVERWRITE`, and `UpdateStrategy.RENAME`.  The rename strategy
+is only available on Windows for single file bundles. Instead of overwriting the binary
+in place, it renames and hides the currently executing app to make place for the
+new executable.  This is useful if you encounter antivirus warnings using the overwrite strategy
+on Windows, which relies .vbs and .bat files.
+
 test (bool): Used to initialize a test client
 
 #### Methods

--- a/pyupdater/client/__init__.py
+++ b/pyupdater/client/__init__.py
@@ -44,7 +44,7 @@ import ed25519
 
 from pyupdater import settings, __version__
 from pyupdater.client.downloader import FileDownloader
-from pyupdater.client.updates import AppUpdate, get_highest_version, LibUpdate
+from pyupdater.client.updates import AppUpdate, get_highest_version, LibUpdate, UpdateStrategy
 from pyupdater.utils.config import Config as _Config
 from pyupdater.utils.exceptions import ClientError
 
@@ -85,6 +85,8 @@ class Client(object):
     data_dir (str): Path to custom update folder
 
     headers (dict): A dictionary of generic and/or urllib3.utils.make_headers compatible headers
+
+    strategy (str): The update strategy to use (default: overwrite).  See the UpdateStrategy enum for options.
 
     test (bool): Used to initialize a test client
 
@@ -197,6 +199,9 @@ class Client(object):
 
         # Creating data & update directories
         self._setup()
+
+        # The update strategy to use
+        self.strategy = kwargs.get("strategy", UpdateStrategy.DEFAULT)
 
         if refresh is True:
             self.refresh()
@@ -313,6 +318,7 @@ class Client(object):
             "progress_hooks": list(set(self.progress_hooks)),
             "headers": self.headers,
             "downloader": self.downloader,
+            "strategy": self.strategy,
         }
 
         data.update(self._gen_file_downloader_options())


### PR DESCRIPTION
This new update strategy renames the currently running binary instead of overwriting it.  The updated binary is then moved into place.  The advantage of this is that it avoids antivirus problems that the use of vbs files can raise with the current mechanism, but the downside is that two binaries can exist at any given point in time.

Algorithm:
(1) Rename the currently running executable, win.exe, to win.exe.old and set the hidden file attribute on win.exe.old. Note this is perfectly valid to do on a running Windows process - you can call os.rename(sys.executable, sys.exectuable + ".old") but not os.move.
(2) Download and extract the updated executable to win.exe since that file name is no longer taken
(3) Launch the new executable and exit process

Resolves issue #208.

Nomenclature is based off the strategy pattern (read more [here](https://en.wikipedia.org/wiki/Strategy_pattern)).
Code changes are backwards compatible - the default strategy is the overwrite strategy that PyUpdater currently uses.  The only time the code in the PR will be called is if a user specifies the use of the rename strategy on a Windows OS with a single file bundle.

You can specify the strategy like so:
```
client = Client(
        client_config,
        refresh=False,
        progress_hooks=[print_status_info],
        data_dir=exe_dir(),
        headers={"Authorization": f"Bearer {access_token}",
        strategy=UpdateStrategy.RENAME
    )
```