### PR TITLE
Fix docs for development install command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,4 +29,4 @@ Be sure to check the plugins docs for setup & configuration options.
 #### Install Development version
 We are not responsible for broken things but please report your findings ;)
 
-    $ pip install --upgrade https://github.com/JMSwag/PyUpdater.git@master
+    $ pip install --upgrade git+https://github.com/Digital-Sapphire/PyUpdater.git@master


### PR DESCRIPTION
The install command was pointing at an old version (?) of the git repo, and was missing the `git+` bit. 