### PR TITLE
Fix false positive on `file_requires_admin` on Windows

### DIFF
--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -61,12 +61,7 @@ def requires_admin(path):  # pragma: no cover
 
 def file_requires_admin(file_path):  # pragma: no cover
     """Check if a file requires admin permissions change."""
-    try:
-        with open(file_path, "a"):
-            pass
-        return False
-    except PermissionError:
-        return True
+    return not os.access(file_path, os.W_OK)
 
 
 def dir_requires_admin(_dir):  # pragma: no cover


### PR DESCRIPTION
Use `os.access(file_path, os.W_OK)` instead of `open(file_path, "a+")` to check write privileges.

Solves #286 .