### PR TITLE
Fix issue299: parse package filename before creating Version

### DIFF
--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -32,6 +32,7 @@ from dsdev_utils.exceptions import VersionError
 from dsdev_utils.helpers import Version
 from dsdev_utils.paths import ChDir, remove_any
 
+from pyupdater.utils import parse_archive_name
 from pyupdater.utils.exceptions import PackageHandlerError, UtilsError
 
 log = logging.getLogger(__name__)
@@ -129,10 +130,6 @@ class Package(object):
 
         filename (str): path to update file
     """
-
-    # Used to parse name from archive filename
-    name_regex = re.compile(r"(?P<name>[\w -]+)-(arm|mac|nix|win)")
-
     def __init__(self, filename):
         if sys.version_info[1] == 5:
             filename = str(filename)
@@ -181,48 +178,28 @@ class Package(object):
             log.debug(msg)
             return
 
-        log.debug("Extracting update archive info for: %s", package_basename)
+        log.debug(f"Extracting update archive info for: {package_basename}")
+        parts = parse_archive_name(package_basename)
+        msg = None
+        version = None  # is this necessary?
         try:
-            v = Version(package_basename)
-            self.channel = v.channel
-            self.version = str(v)
+            # parse version
+            version = Version(parts["version"])
+            log.debug("Got version info")
+        except TypeError:
+            msg = "Package filename does not match expected format"
         except VersionError:
-            msg = "Package version not formatted correctly: {}"
-            self.info["reason"] = msg.format(package_basename)
-            log.error(msg)
-            return
-        log.debug("Got version info")
-
-        try:
-            self.platform = parse_platform(package_basename)
-        except PackageHandlerError:
-            msg = "Package platform not formatted correctly"
-            self.info["reason"] = msg
-            log.error(msg)
-            return
-        log.debug("Got platform info")
-
-        self.name = self._parse_package_name(package_basename)
-        assert self.name is not None
-        log.debug("Got name of update: %s", self.name)
+            msg = "dsdev-utils cannot parse package version"
+        except AttributeError:
+            msg = "Package version may not be PEP440 compliant"
+        finally:
+            if msg is not None:
+                self.info["reason"] = f"{msg}: {package_basename}"
+                log.error(msg)
+                return
+        self.name = parts["app_name"]
+        self.platform = parts["platform"]
+        self.channel = version.channel
+        self.version = str(version)
         self.info["status"] = True
         log.debug("Info extraction complete")
-
-    def _parse_package_name(self, package):
-        # Returns package name from update archive name
-        # Changes appname-platform-version to appname
-        #
-        # May need to update regex if support for app names with
-        # hyphens in them are requested. Example "My-App"
-        log.debug("Package name: %s", package)
-        basename = os.path.basename(package)
-
-        r = self.name_regex.search(basename)
-        try:
-            name = r.groupdict()["name"]
-        except Exception as err:
-            self.info["reason"] = str(err)
-            name = None
-
-        log.debug("Regex name: %s", name)
-        return name

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -131,7 +131,7 @@ class Package(object):
     """
 
     # Used to parse name from archive filename
-    name_regex = re.compile(r"(?P<name>[\w -]+)-[arm|mac|nix|win]")
+    name_regex = re.compile(r"(?P<name>[\w -]+)-(arm|mac|nix|win)")
 
     def __init__(self, filename):
         if sys.version_info[1] == 5:

--- a/pyupdater/utils/__init__.py
+++ b/pyupdater/utils/__init__.py
@@ -27,6 +27,7 @@ import io
 import logging
 import json
 import os
+import re
 import shutil
 import subprocess
 import tarfile
@@ -314,6 +315,25 @@ def make_archive(name, target, version, archive_format):
 
     log.debug("Archive output filename: %s", output_filename)
     return output_filename
+
+
+def parse_archive_name(filename):
+    """
+    Parse a filename created by make_archive(), to extract app_name, platform,
+    version, and extension strings.
+
+    We do not impose any versioning requirements yet, such as defined in
+    packaging.version.VERSION_PATTERN.
+    """
+    archive_name_pattern = (
+        r"^(?P<app_name>[\w -]+)"
+        r"-"
+        r"(?P<platform>arm(64)?|mac|nix(64)?|win)"
+        r"-"
+        r"(?P<version>.+)"
+        r"(?P<extension>\.zip|\.tar\.gz)$")
+    match = re.search(pattern=archive_name_pattern, string=filename)
+    return match.groupdict() if match else None
 
 
 def remove_dot_files(files):

--- a/tests/test_package_handler.py
+++ b/tests/test_package_handler.py
@@ -141,17 +141,16 @@ class TestPackage(object):
             "Not a supported archive format: " "{}".format(test_file_2)
         )
 
-    def test_package_bad_version(self, shared_datadir):
+    def test_package_only_major_version(self, shared_datadir):
         filename = "pyu-win-1.tar.gz"
         p = Package(shared_datadir / filename)
-        out = "Package version not formatted correctly: {}"
-        assert p.info["reason"] == out.format(filename)
+        assert p.info["reason"] == ''
 
     def test_package_bad_platform(self, shared_datadir):
         filename = "pyu-wi-1.1.tar.gz"
         p = Package(shared_datadir / filename)
-        out = "Package platform not formatted correctly"
-        assert p.info["reason"] == out
+        out = "filename does not match expected format"
+        assert out in p.info["reason"].lower()
 
 
 @pytest.mark.usefixtures("cleandir")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,7 @@ from pyupdater.utils import (
     check_repo,
     create_asset_archive,
     make_archive,
+    parse_archive_name,
     PluginManager,
     remove_dot_files,
     run,
@@ -53,6 +54,21 @@ class TestUtils(object):
 
         assert os.path.exists(filename1)
         assert os.path.exists(filename2)
+
+    @pytest.mark.parametrize(
+        ["filename", "expected"],
+        [("Acme-mac-4.1.tar.gz", ("Acme", "mac", "4.1", ".tar.gz")),
+         ("with spaces-nix-0.0.1b1.zip", ("with spaces", "nix", "0.0.1b1", ".zip")),
+         ("with spaces-win-0.0.1a2.zip", ("with spaces", "win", "0.0.1a2", ".zip")),
+         ("pyu-win-1.tar.gz", ("pyu", "win", "1", ".tar.gz")),
+         ("pyu-win-0.0.2.xz", None),
+         ("pyu-wi-1.1.tar.gz", None),
+         ("anything", None),
+         ]
+    )
+    def test_parse_archive_name(self, filename, expected):
+        parts = parse_archive_name(filename)
+        assert parts == expected or tuple(parts.values()) == expected
 
     def test_create_asset_archive(self):
         with io.open("hash-test1.dll", "w", encoding="utf-8") as f:


### PR DESCRIPTION
This is an attempt to fix issue #299.

- Introduces a separate `parse_archive_name()` (with tests) to extract the version string from the filename before instantiating a `dsdev_utils.helpers.Version` 
- catches `AttributeError` due to `packaging.version.LegacyVersion`
- removes `Package._parse_package_name()` as it is replaced by `parse_archive_name()` (no deprecation because it is "private"...)
- removes `Package.name_regex` which was broken anyway
