### PR TITLE
Fix issue 315: Use packaging.version.Version instead of dsdev-utils.helpers.Version

### DIFF
--- a/pyupdater/cli/options.py
+++ b/pyupdater/cli/options.py
@@ -25,15 +25,6 @@
 import argparse
 import packaging.version
 
-# The VALID_CHANNELS index corresponds with the <release> value in the internal
-# version format, <major>.<minor>.<patch>.<release>.<release version>,
-# as defined here:
-# https://github.com/Digital-Sapphire/dsdev-utils/blob/1.3.0/dsdev_utils/helpers.py#L192
-# Also see:
-# https://github.com/Digital-Sapphire/PyUpdater/blob/4.0/pyupdater/client/updates.py#L198
-# https://github.com/Digital-Sapphire/PyUpdater/blob/4.0/pyupdater/core/package_handler/package.py#L188
-VALID_CHANNELS = ["alpha", "beta", "stable"]
-
 
 def make_parser():
     parser = argparse.ArgumentParser(usage="%(prog)s ")

--- a/pyupdater/cli/options.py
+++ b/pyupdater/cli/options.py
@@ -24,6 +24,15 @@
 # ------------------------------------------------------------------------------
 import argparse
 
+# The VALID_CHANNELS index corresponds with the <release> value in the internal
+# version format, <major>.<minor>.<patch>.<release>.<release version>,
+# as defined here:
+# https://github.com/Digital-Sapphire/dsdev-utils/blob/1.3.0/dsdev_utils/helpers.py#L192
+# Also see:
+# https://github.com/Digital-Sapphire/PyUpdater/blob/4.0/pyupdater/client/updates.py#L198
+# https://github.com/Digital-Sapphire/PyUpdater/blob/4.0/pyupdater/core/package_handler/package.py#L188
+VALID_CHANNELS = ["alpha", "beta", "stable"]
+
 
 def make_parser():
     parser = argparse.ArgumentParser(usage="%(prog)s ")

--- a/pyupdater/cli/options.py
+++ b/pyupdater/cli/options.py
@@ -23,6 +23,7 @@
 # OR OTHER DEALINGS IN THE SOFTWARE.
 # ------------------------------------------------------------------------------
 import argparse
+import packaging.version
 
 # The VALID_CHANNELS index corresponds with the <release> value in the internal
 # version format, <major>.<minor>.<patch>.<release>.<release version>,
@@ -92,6 +93,21 @@ def add_archive_parser(subparsers):
     )
 
 
+class VersionCheckAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None, **kwargs):
+        # Check PEP440 compliance
+        try:
+            packaging.version.Version(values)
+        except packaging.version.InvalidVersion:
+            msg = (
+                f"Version string '{values}' is not PEP440 compliant.\n"
+                f"For examples, see https://www.python.org/dev/peps/pep-0440/."
+            )
+            raise argparse.ArgumentError(self, msg)
+        # Store the value, same as "store" action
+        setattr(namespace, self.dest, values)
+
+
 def add_build_parser(subparsers):
     build_parser = subparsers.add_parser(
         "build", help="Compiles script " "or spec file", usage="%(prog)s [opts]<script>"
@@ -106,7 +122,12 @@ def add_build_parser(subparsers):
         "--clean", action="store_true", help="Clean build. Bypass the cache"
     )
 
-    build_parser.add_argument("--app-version", dest="app_version", required=True)
+    build_parser.add_argument(
+        "--app-version",
+        dest="app_version",
+        required=True,
+        action=VersionCheckAction,
+    )
     build_parser.add_argument(
         "-k",
         "--keep",

--- a/pyupdater/client/__init__.py
+++ b/pyupdater/client/__init__.py
@@ -287,8 +287,8 @@ class Client(object):
             app = True
 
         log.debug("Checking for %s updates...", name)
-        latest = get_highest_version(
-            name, self.platform, channel, self.easy_version_data, strict
+        latest_version = get_highest_version(
+            name, self.platform, channel, self.version_data, strict
         )
         if latest is None:
             # If None is returned get_highest_version could

--- a/pyupdater/client/__init__.py
+++ b/pyupdater/client/__init__.py
@@ -32,7 +32,6 @@ import warnings
 from typing import Optional
 
 import appdirs
-import packaging.version
 from dsdev_utils.app import app_cwd, FROZEN
 from dsdev_utils.helpers import (
     EasyAccessDict,
@@ -51,6 +50,7 @@ from pyupdater.client.updates import (
     LibUpdate,
     UpdateStrategy,
 )
+from pyupdater.utils import PyuVersion
 from pyupdater.utils.config import Config as _Config
 from pyupdater.utils.encoding import UnpaddedBase64Encoder
 from pyupdater.utils.exceptions import ClientError
@@ -120,7 +120,7 @@ class Client(object):
         self.name = None
 
         # Version of the binary to update
-        self.current_version: Optional[packaging.version.Version] = None
+        self.current_version: Optional[PyuVersion] = None
 
         # Update manifest as dict - set in _get_update_manifest
         self.version_data = None
@@ -243,9 +243,9 @@ class Client(object):
 
             None - No Updates available
         """
-        # Convert version string to Version object (only work with version
-        # objects internally).
-        current_version = packaging.version.Version(version)
+        # Convert version string to Version object (only use version strings
+        # for input and output, use Version objects internally).
+        current_version = PyuVersion(version)
         return self._update_check(name, current_version, channel, strict)
 
     def _gen_file_downloader_options(self):

--- a/pyupdater/client/patcher.py
+++ b/pyupdater/client/patcher.py
@@ -279,7 +279,7 @@ class Patcher(object):
             versions = [
                 v
                 for v in versions
-                if self.channel and self.channel.startswith(v.pre[0])
+                if v.is_prerelease and self.channel and self.channel.startswith(v.pre[0])
             ]
 
         log.debug("Getting required patches")

--- a/pyupdater/client/patcher.py
+++ b/pyupdater/client/patcher.py
@@ -49,7 +49,7 @@ class Patcher(object):
 
         name (str): Name of binary to patch
 
-        json_data (dict): Info dict with all package meta data
+        version_data (dict): Info dict with all package meta data
 
         current_version (str): Version number of currently installed binary
 
@@ -75,8 +75,8 @@ class Patcher(object):
     def __init__(self, **kwargs):
         self.name = kwargs.get("name")
         self.channel = kwargs.get("channel")
-        self.json_data = kwargs.get("json_data")
-        self.star_access_update_data = EasyAccessDict(self.json_data)
+        self.version_data = kwargs.get("version_data")
+        self.easy_version_data = EasyAccessDict(self.version_data)
         self.current_version = Version(kwargs.get("current_version"))
         self.latest_version = kwargs.get("latest_version")
         self.update_folder = kwargs.get("update_folder")
@@ -205,7 +205,7 @@ class Patcher(object):
             platform_key = "{}*{}*{}*{}".format(
                 settings.UPDATES_KEY, self.name, str(p), self.platform
             )
-            platform_info = self.star_access_update_data.get(platform_key)
+            platform_info = self.easy_version_data.get(platform_key)
 
             try:
                 info["patch_name"] = platform_info["patch_name"]
@@ -260,7 +260,7 @@ class Patcher(object):
             # Get list of Version objects initialized with keys
             # from update manifest
             version_key = "{}*{}".format(settings.UPDATES_KEY, name)
-            version_info = self.star_access_update_data(version_key)
+            version_info = self.easy_version_data(version_key)
             versions = map(Version, version_info.keys())
         except KeyError:  # pragma: no cover
             log.debug("No updates found in updates dict")
@@ -375,7 +375,7 @@ class Patcher(object):
             self.platform,
             "filename",
         )
-        filename = self.star_access_update_data.get(filename_key)
+        filename = self.easy_version_data.get(filename_key)
 
         if filename is None:
             raise PatcherError("Filename missing in version file")
@@ -419,7 +419,7 @@ class Patcher(object):
         platform_key = "{}*{}*{}*{}".format(
             settings.UPDATES_KEY, name, version, self.platform
         )
-        platform_info = self.star_access_update_data.get(platform_key)
+        platform_info = self.easy_version_data.get(platform_key)
 
         info = {}
         if platform_info is not None:

--- a/pyupdater/client/patcher.py
+++ b/pyupdater/client/patcher.py
@@ -246,14 +246,7 @@ class Patcher(object):
             else:
                 return True
         else:
-            return Patcher._calc_diff(total_patch_size, latest_file_size)
-
-    @staticmethod
-    def _calc_diff(patch_size, file_size):
-        if patch_size < file_size:
-            return True
-        else:
-            return False
+            return total_patch_size < latest_file_size
 
     def _get_required_patches(self, name):
         # Gathers patch name, hash & URL

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -140,7 +140,7 @@ def get_highest_version(name, plat, channel, easy_data, strict):
     """
     latest_versions = dict(
         (_channel, versions[plat])
-        for _channel, versions in easy_data.dict["latest"][name].items()
+        for _channel, versions in easy_data.dict[settings.LATEST_KEY][name].items()
     )
 
     version_objects = [

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -181,7 +181,7 @@ def gen_user_friendly_version(internal_version):
 
 def gen_pep440_version(internal_version):
     """
-    Convert an internal version string to a PEP440-compliant version string
+    Convert an internal version string to a PEP440-compatible version string
     that can be parsed by packaging.version.parse().
 
     The pyupdater internal version format is (from dsdev-utils):

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -204,9 +204,9 @@ def gen_pep440_version(internal_version):
         channel_index = int(internal_version_parts[3])
         release_number = int(internal_version_parts[4])
     except IndexError:
-        msg = f"internal_version format must be 'N.N.N.N.N' (N is numeric)"
+        msg = "internal_version format must be 'N.N.N.N.N' (N is numeric)"
     except ValueError:
-        msg = f"internal_version parts must be numeric, e.g. '1.2.3.4.5'"
+        msg = "internal_version parts must be numeric, e.g. '1.2.3.4.5'"
     finally:
         if msg is not None:
             raise ValueError(f"{msg}: {internal_version}")

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -38,12 +38,12 @@ from typing import Optional
 
 from dsdev_utils.paths import ChDir, get_mac_dot_app_dir, remove_any
 from dsdev_utils.system import get_system
-import packaging.version
 
 from pyupdater import settings
 from pyupdater.client.downloader import FileDownloader, get_hash
 from pyupdater.client.patcher import Patcher
 from pyupdater.core.package_handler.package import remove_previous_versions
+from pyupdater.utils import PyuVersion
 from pyupdater.utils.exceptions import ClientError
 
 
@@ -117,7 +117,7 @@ def win_run(command, args, admin=False):  # pragma: no cover
         subprocess.Popen([command] + args)
 
 
-def get_highest_version(name, platform, channel, version_data, strict) -> Optional[packaging.version.Version]:
+def get_highest_version(name, platform, channel, version_data, strict) -> Optional[PyuVersion]:
     """
     Parses version file and returns the highest version number.
 
@@ -144,7 +144,7 @@ def get_highest_version(name, platform, channel, version_data, strict) -> Option
     )
 
     version_objects = [
-        packaging.version.Version(version_string)
+        PyuVersion(version_string)
         for version_string in latest_version_strings.values()
     ]
 
@@ -155,7 +155,7 @@ def get_highest_version(name, platform, channel, version_data, strict) -> Option
 
     if version_string is not None:
         log.debug(f"Highest version: {version_string}")
-        return packaging.version.Version(version_string)
+        return PyuVersion(version_string)
     else:
         log.info(f"No updates exist for '{name}' on {platform}")
         return
@@ -494,12 +494,13 @@ class LibUpdate(object):
 
             (str) Filename with extension
         """
+        version_key = version.pyu_format()
         filename_key = "{}*{}*{}*{}*{}".format(
-            settings.UPDATES_KEY, name, version, platform, "filename"
+            settings.UPDATES_KEY, name, version_key, platform, "filename"
         )
         filename = easy_version_data.get(filename_key)
 
-        log.debug("Filename for %s-%s: %s", name, version, filename)
+        log.debug("Filename for %s-%s: %s", name, version_key, filename)
         return filename
 
     def _download(self):

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -35,9 +35,9 @@ import threading
 import zipfile
 import ctypes
 
-from dsdev_utils.helpers import Version
 from dsdev_utils.paths import ChDir, get_mac_dot_app_dir, remove_any
 from dsdev_utils.system import get_system
+import packaging.version
 
 from pyupdater import settings
 from pyupdater.client.downloader import FileDownloader, get_hash
@@ -357,10 +357,10 @@ class LibUpdate(object):
 
         # A special dictionary that allows getting nested values by
         # providing a key in the form of "this*is*a*deep*key".
-        self.easy_data = data.get("easy_data")
+        self.easy_version_data = data.get("easy_version_data")
 
-        # Raw form of easy_data
-        self.json_data = data.get("json_data")
+        # Raw form of easy_version_data
+        self.version_data = data.get("version_data")
 
         # The directory used to store files needed for the restart process
         # on windows
@@ -400,7 +400,7 @@ class LibUpdate(object):
 
         # The latest version available
         self.latest = get_highest_version(
-            self.name, self.platform, self.channel, self.easy_data, self.strict
+            self.name, self.platform, self.channel, self.easy_version_data, self.strict
         )
 
         # The name of the current versions update archive.
@@ -408,12 +408,12 @@ class LibUpdate(object):
         # patch update
         cv = self.current_version
         self._current_archive_name = LibUpdate._get_filename(
-            self.name, cv, self.platform, self.easy_data
+            self.name, cv, self.platform, self.easy_version_data
         )
 
         # Get filename of latest versions update archive
         self.filename = LibUpdate._get_filename(
-            self.name, self.latest, self.platform, self.easy_data
+            self.name, self.latest, self.platform, self.easy_version_data
         )
         assert self.filename is not None
 
@@ -480,7 +480,7 @@ class LibUpdate(object):
         return True
 
     @staticmethod
-    def _get_filename(name, version, platform, easy_data):
+    def _get_filename(name, version, platform, easy_version_data):
         """Gets full filename for given name & version combo
 
         Args:
@@ -489,7 +489,7 @@ class LibUpdate(object):
 
             version (str): Version of file to get full filename for
 
-            easy_data (dict): Data file to search
+            easy_version_data (dict): Data file to search
 
         Returns:
 
@@ -498,7 +498,7 @@ class LibUpdate(object):
         filename_key = "{}*{}*{}*{}*{}".format(
             settings.UPDATES_KEY, name, version, platform, "filename"
         )
-        filename = easy_data.get(filename_key)
+        filename = easy_version_data.get(filename_key)
 
         log.debug("Filename for %s-%s: %s", name, version, filename)
         return filename
@@ -570,7 +570,7 @@ class LibUpdate(object):
         hash_key = "{}*{}*{}*{}*{}".format(
             self._updates_key, self.name, self.latest, self.platform, "file_hash"
         )
-        return self.easy_data.get(hash_key)
+        return self.easy_version_data.get(hash_key)
 
     # Must be called from directory where file is located
     def _verify_file_hash(self):

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -567,8 +567,9 @@ class LibUpdate(object):
                 raise ClientError("Update archive is corrupt")
 
     def _get_file_hash_from_manifest(self):
+        version_key = self.latest_version.pyu_format()
         hash_key = "{}*{}*{}*{}*{}".format(
-            self._updates_key, self.name, self.latest_version, self.platform, "file_hash"
+            self._updates_key, self.name, version_key, self.platform, "file_hash"
         )
         return self.easy_version_data.get(hash_key)
 

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -353,7 +353,7 @@ class LibUpdate(object):
         self.app_name = data.get("app_name")
 
         # The version of the current asset
-        self.current_version = data.get("version")
+        self.current_version = data.get("current_version")
 
         # A special dictionary that allows getting nested values by
         # providing a key in the form of "this*is*a*deep*key".
@@ -406,14 +406,13 @@ class LibUpdate(object):
         # The name of the current versions update archive.
         # Will be used to check if the current archive is available for a
         # patch update
-        cv = self.current_version
         self._current_archive_name = LibUpdate._get_filename(
-            self.name, cv, self.platform, self.easy_version_data
+            self.name, self.current_version, self.platform, self.easy_version_data
         )
 
         # Get filename of latest versions update archive
         self.filename = LibUpdate._get_filename(
-            self.name, self.latest, self.platform, self.easy_version_data
+            self.name, self.latest_version, self.platform, self.easy_version_data
         )
         assert self.filename is not None
 
@@ -427,7 +426,7 @@ class LibUpdate(object):
         ######Returns (str): User friendly version string
         """
         if self._version == "":
-            self._version = str(self.latest)
+            self._version = str(self.latest_version)
         return self._version
 
     def is_downloaded(self):
@@ -487,7 +486,7 @@ class LibUpdate(object):
 
             name (str): Name of file
 
-            version (str): Version of file to get full filename for
+            version: Version of file to get full filename for
 
             easy_version_data (dict): Data file to search
 
@@ -568,7 +567,7 @@ class LibUpdate(object):
 
     def _get_file_hash_from_manifest(self):
         hash_key = "{}*{}*{}*{}*{}".format(
-            self._updates_key, self.name, self.latest, self.platform, "file_hash"
+            self._updates_key, self.name, self.latest_version, self.platform, "file_hash"
         )
         return self.easy_version_data.get(hash_key)
 
@@ -620,7 +619,7 @@ class LibUpdate(object):
         # Initialize Patch object with all required information
         p = Patcher(
             current_version=self.current_version,
-            latest_version=self.latest,
+            latest_version=self.latest_version,
             update_folder=self.update_folder,
             **self.init_data
         )

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -40,6 +40,7 @@ from dsdev_utils.paths import ChDir, get_mac_dot_app_dir, remove_any
 from dsdev_utils.system import get_system
 
 from pyupdater import settings
+from pyupdater.cli.options import VALID_CHANNELS
 from pyupdater.client.downloader import FileDownloader, get_hash
 from pyupdater.client.patcher import Patcher
 from pyupdater.core.package_handler.package import remove_previous_versions
@@ -206,6 +207,24 @@ def gen_user_friendly_version(internal_version):
             version += " {}".format(v[4])
 
     return version
+
+
+def gen_pep440_version(internal_version):
+    """
+    The internal version format is:
+
+        <major>.<minor>.<patch>.<release>.<release version>
+
+    Note: function name consistent with gen_user_friendly_version()
+    """
+    internal_version_parts = internal_version.split(".")
+    if len(internal_version_parts) != 5:
+        raise ValueError(
+            f"Invalid internal_version: {internal_version} (must be N.N.N.N.N)")
+    channel_index = int(internal_version_parts[3])
+    if channel_index in [0, 1]:
+        internal_version_parts[3] = VALID_CHANNELS[channel_index]
+    return ".".join(internal_version_parts)
 
 
 class UpdateStrategy:  # pragma: no cover

--- a/pyupdater/client/updates.py
+++ b/pyupdater/client/updates.py
@@ -40,7 +40,6 @@ from dsdev_utils.paths import ChDir, get_mac_dot_app_dir, remove_any
 from dsdev_utils.system import get_system
 
 from pyupdater import settings
-from pyupdater.cli.options import VALID_CHANNELS
 from pyupdater.client.downloader import FileDownloader, get_hash
 from pyupdater.client.patcher import Patcher
 from pyupdater.core.package_handler.package import remove_previous_versions
@@ -212,7 +211,7 @@ def gen_pep440_version(internal_version):
             raise ValueError(f"{msg}: {internal_version}")
 
     if channel_index in [0, 1]:
-        internal_version_parts[3] = VALID_CHANNELS[channel_index]
+        internal_version_parts[3] = settings.VALID_CHANNELS[channel_index]
     elif channel_index == 2 and release_number > 0:
         pass
         # todo: Do we consider this a post release? In that case:

--- a/pyupdater/core/key_handler/keys.py
+++ b/pyupdater/core/key_handler/keys.py
@@ -151,7 +151,7 @@ class KeyImporter(object):
 
     @staticmethod
     def _load_keypack():
-        json_data = None
+        key_data = None
         try:
             with io.open(settings.KEYPACK_FILENAME, "r", encoding="utf-8") as f:
                 data = f.read()
@@ -159,10 +159,10 @@ class KeyImporter(object):
             log.debug(err, exc_info=True)
         else:
             try:
-                json_data = json.loads(data)
+                key_data = json.loads(data)
             except Exception as err:
                 log.debug(err, exc_info=True)
-        return json_data
+        return key_data
 
     def start(self):
         found = KeyImporter._look_for_keypack()

--- a/pyupdater/core/package_handler/__init__.py
+++ b/pyupdater/core/package_handler/__init__.py
@@ -111,9 +111,9 @@ class PackageHandler(object):
         PackageHandler._add_patches_to_packages(
             pkg_manifest, patches, self.patch_support
         )
-        PackageHandler._update_version_file(self.version_data, pkg_manifest)
+        PackageHandler._update_version_meta(self.version_data, pkg_manifest)
 
-        self._write_json_to_file(self.version_data)
+        self._write_version_meta_to_file(self.version_data)
         self._write_config_to_file(self.config)
         self._move_packages(pkg_manifest)
 
@@ -327,9 +327,8 @@ class PackageHandler(object):
         return info
 
     @staticmethod
-    def _update_version_file(json_data, package_manifest):
-        # Adding version metadata from scanned packages to our
-        # version manifest
+    def _update_version_meta(json_data, package_manifest):
+        # Adding version metadata from scanned packages to our version manifest
         log.info("Adding package meta-data to version manifest")
         easy_dict = EasyAccessDict(json_data)
         for p in package_manifest:
@@ -365,7 +364,7 @@ class PackageHandler(object):
             json_data["latest"][p.name][p.channel][p.platform] = p.version
         return json_data
 
-    def _write_json_to_file(self, json_data):
+    def _write_version_meta_to_file(self, json_data):
         # Writes json data to disk
         log.debug("Saving version meta-data")
         self.db.save(settings.CONFIG_DB_KEY_VERSION_META, json_data)

--- a/pyupdater/core/package_handler/__init__.py
+++ b/pyupdater/core/package_handler/__init__.py
@@ -145,7 +145,7 @@ class PackageHandler(object):
         version_data = self.db.load(settings.CONFIG_DB_KEY_VERSION_META)
         if version_data is None:  # pragma: no cover
             log.warning("Version file not found")
-            version_data = {"updates": {}}
+            version_data = {settings.UPDATES_KEY: {}}
             log.debug("Created new version file")
         return version_data
 
@@ -294,22 +294,22 @@ class PackageHandler(object):
     @staticmethod
     def _update_file_list(version_data, package_info):
         files = version_data[settings.UPDATES_KEY]
-        latest = version_data.get("latest")
+        latest = version_data.get(settings.LATEST_KEY)
         if latest is None:
-            version_data["latest"] = {}
+            version_data[settings.LATEST_KEY] = {}
         filename = files.get(package_info.name)
         if filename is None:
             log.debug("Adding %s to file list", package_info.name)
             version_data[settings.UPDATES_KEY][package_info.name] = {}
 
-        latest_package = version_data["latest"].get(package_info.name)
+        latest_package = version_data[settings.LATEST_KEY].get(package_info.name)
         if latest_package is None:
-            version_data["latest"][package_info.name] = {}
+            version_data[settings.LATEST_KEY][package_info.name] = {}
 
-        latest_package = version_data["latest"][package_info.name]
+        latest_package = version_data[settings.LATEST_KEY][package_info.name]
         latest_channel = latest_package.get(package_info.channel)
         if latest_channel is None:
-            version_data["latest"][package_info.name][package_info.channel] = {}
+            version_data[settings.LATEST_KEY][package_info.name][package_info.channel] = {}
         return version_data
 
     @staticmethod
@@ -365,7 +365,7 @@ class PackageHandler(object):
                 _updates[p.name][version_key][p.platform] = info
 
             # Add each package to latest section separated by release channel
-            version_data["latest"][p.name][p.channel][p.platform] = version_key
+            version_data[settings.LATEST_KEY][p.name][p.channel][p.platform] = version_key
         return version_data
 
     def _write_version_meta_to_file(self, version_data):

--- a/pyupdater/core/package_handler/__init__.py
+++ b/pyupdater/core/package_handler/__init__.py
@@ -32,10 +32,9 @@ import sys
 from dsdev_utils.crypto import get_package_hashes as gph
 from dsdev_utils.helpers import EasyAccessDict
 from dsdev_utils.paths import ChDir
-import packaging.version
 
 from pyupdater import settings
-from pyupdater.utils import get_size_in_bytes as in_bytes
+from pyupdater.utils import PyuVersion, get_size_in_bytes as in_bytes
 from pyupdater.utils.storage import Storage
 
 from .package import remove_previous_versions, Package
@@ -221,7 +220,7 @@ class PackageHandler(object):
             data["package"] = {}
             log.debug("Initializing config for packages")
         # First package with current name so add platform and version
-        version_key = str(p.version)
+        version_key = p.version.pyu_format()
         if p.name not in data["package"].keys():
             data["package"][p.name] = {p.platform: version_key}
             log.debug("Adding new package to config")
@@ -232,7 +231,7 @@ class PackageHandler(object):
                 log.debug("Adding new arch to package-config: %s", p.platform)
             else:
                 # Getting current version for platform
-                current_version = packaging.version.Version(data["package"][p.name][p.platform])
+                current_version = PyuVersion(data["package"][p.name][p.platform])
                 # Updating version if applicable
                 # todo: what about release channels?
                 if p.version > current_version:
@@ -337,7 +336,7 @@ class PackageHandler(object):
         for p in package_manifest:
             info = PackageHandler._manifest_to_version_file_compat(p)
 
-            version_key = str(p.version)
+            version_key = p.version.pyu_format()
             easy_key = "{}*{}*{}".format(settings.UPDATES_KEY, p.name, version_key)
             existing_version = easy_dict.get(easy_key)
             log.debug("Package Info: %s", existing_version or "none")

--- a/pyupdater/core/package_handler/__init__.py
+++ b/pyupdater/core/package_handler/__init__.py
@@ -199,7 +199,7 @@ class PackageHandler(object):
                         "filename": p,
                         "files_dir": self.files_dir,
                         "new_dir": self.new_dir,
-                        "json_data": self.version_data,
+                        "version_data": self.version_data,
                         "pkg_info": new_pkg,
                         "config": self.config,
                     }

--- a/pyupdater/core/package_handler/__init__.py
+++ b/pyupdater/core/package_handler/__init__.py
@@ -232,10 +232,10 @@ class PackageHandler(object):
                 log.debug("Adding new arch to package-config: %s", p.platform)
             else:
                 # Getting current version for platform
-                value = data["package"][p.name][p.platform]
+                current_version = packaging.version.Version(data["package"][p.name][p.platform])
                 # Updating version if applicable
                 # todo: what about release channels?
-                if p.version > packaging.version.Version(value):
+                if p.version > current_version:
                     log.debug("Adding new version to package-config")
                     data["package"][p.name][p.platform] = version_key
 

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -153,8 +153,11 @@ class Package(object):
     @property
     def channel(self):
         """
-        todo: this information is already contained in the Version object,
-         so it may be clearer just to drop the whole channel attribute
+        todo: Release notes should mention that Package.channel is now a
+         property instead of a normal attribute.
+
+        todo: This information is already contained in the Version object,
+         so it may be clearer just to drop the whole channel attribute.
         """
         channel_index = 2
         if self.version.is_prerelease:
@@ -194,7 +197,9 @@ class Package(object):
         parts = parse_archive_name(package_basename)
         msg = None
         try:
-            # parse PEP440 version string
+            # Parse PEP440 version string
+            # todo: Release notes should mention that Package.version is now a
+            #  packaging.version.Version object instead of a string.
             self.version = packaging.version.Version(parts["version"])
             log.debug("Got version info")
         except TypeError:

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -27,11 +27,12 @@ import logging
 import os
 import re
 import sys
+from typing import Optional
 
-from dsdev_utils.exceptions import VersionError
-from dsdev_utils.helpers import Version
 from dsdev_utils.paths import ChDir, remove_any
+import packaging.version
 
+from pyupdater.cli.options import VALID_CHANNELS
 from pyupdater.utils import parse_archive_name
 from pyupdater.utils.exceptions import PackageHandlerError, UtilsError
 
@@ -78,7 +79,7 @@ def remove_previous_versions(directory, filename):
     try:
         # We set the full path here because Package() checks if filename exists
         package_info = Package(os.path.join(directory, filename))
-    except (UtilsError, VersionError):
+    except (UtilsError, packaging.version.InvalidVersion):
         log.debug("Cleanup Failed: %s - Cannot parse package info.", filename)
         return
 
@@ -135,8 +136,7 @@ class Package(object):
             filename = str(filename)
 
         self.name = None
-        self.channel = None
-        self.version = None
+        self.version: Optional[packaging.version.Version] = None
         self.filename = os.path.basename(filename)
         self.file_hash = None
         self.file_size = None
@@ -149,6 +149,18 @@ class Package(object):
         self.supported_extensions = [".zip", ".gz", ".bz2"]
         self.ignored_files = [".DS_Store"]
         self.extract_info(filename)
+
+    @property
+    def channel(self):
+        """
+        todo: this information is already contained in the Version object,
+         so it may be clearer just to drop the whole channel attribute
+        """
+        channel_index = 2
+        if self.version.is_prerelease:
+            # alpha or beta
+            channel_index = "ab".index(self.version.pre[0])
+        return VALID_CHANNELS[channel_index]
 
     def extract_info(self, package):
         """Gets version number, platform & hash for package.
@@ -180,26 +192,23 @@ class Package(object):
 
         log.debug(f"Extracting update archive info for: {package_basename}")
         parts = parse_archive_name(package_basename)
+        self.name = parts["app_name"]
+        self.platform = parts["platform"]
         msg = None
-        version = None  # is this necessary?
         try:
-            # parse version
-            version = Version(parts["version"])
+            # parse PEP440 version string
+            self.version = packaging.version.Version(parts["version"])
             log.debug("Got version info")
         except TypeError:
             msg = "Package filename does not match expected format"
-        except VersionError:
-            msg = "dsdev-utils cannot parse package version"
-        except AttributeError:
+        except packaging.version.InvalidVersion:
             msg = "Package version may not be PEP440 compliant"
         finally:
             if msg is not None:
-                self.info["reason"] = f"{msg}: {package_basename}"
-                log.error(msg)
+                reason = f"{msg}: {package_basename}"
+                self.info["reason"] = reason
+                log.error(reason)
                 return
-        self.name = parts["app_name"]
-        self.platform = parts["platform"]
-        self.channel = version.channel
-        self.version = str(version)
+
         self.info["status"] = True
         log.debug("Info extraction complete")

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -32,6 +32,7 @@ from dsdev_utils.exceptions import VersionError
 from dsdev_utils.helpers import Version
 from dsdev_utils.paths import ChDir, remove_any
 
+from pyupdater.utils import parse_archive_name
 from pyupdater.utils.exceptions import PackageHandlerError, UtilsError
 
 log = logging.getLogger(__name__)
@@ -129,10 +130,6 @@ class Package(object):
 
         filename (str): path to update file
     """
-
-    # Used to parse name from archive filename
-    name_regex = re.compile(r"(?P<name>[\w -]+)-(arm|mac|nix|win)")
-
     def __init__(self, filename):
         if sys.version_info[1] == 5:
             filename = str(filename)
@@ -181,48 +178,28 @@ class Package(object):
             log.debug(msg)
             return
 
-        log.debug("Extracting update archive info for: %s", package_basename)
+        log.debug(f"Extracting update archive info for: {package_basename}")
+        parts = parse_archive_name(package_basename)
+        msg = None
+        version = None  # is this necessary?
         try:
-            v = Version(package_basename)
-            self.channel = v.channel
-            self.version = str(v)
+            # parse version
+            version = Version(parts["version"])
+            log.debug("Got version info")
+        except TypeError:
+            msg = "Package filename does not match expected format"
         except VersionError:
-            msg = "Package version not formatted correctly: {}"
-            self.info["reason"] = msg.format(package_basename)
-            log.error(msg)
-            return
-        log.debug("Got version info")
-
-        try:
-            self.platform = parse_platform(package_basename)
-        except PackageHandlerError:
-            msg = "Package platform not formatted correctly"
-            self.info["reason"] = msg
-            log.error(msg)
-            return
-        log.debug("Got platform info")
-
-        self.name = self._parse_package_name(package_basename)
-        assert self.name is not None
-        log.debug("Got name of update: %s", self.name)
+            msg = "dsdev-utils cannot parse package version"
+        except AttributeError:
+            msg = "Package version may not be PEP440 compliant"
+        finally:
+            if msg is not None:
+                self.info["reason"] = f"{msg}: {package_basename}"
+                log.error(msg)
+                return
+        self.name = parts["app_name"]
+        self.platform = parts["platform"]
+        self.channel = version.channel
+        self.version = str(version)
         self.info["status"] = True
         log.debug("Info extraction complete")
-
-    def _parse_package_name(self, package):
-        # Returns package name from update archive name
-        # Changes appname-platform-version to appname
-        #
-        # May need to update regex if support for app names with
-        # hyphens in them are requested. Example "My-App"
-        log.debug("Package name: %s", package)
-        basename = os.path.basename(package)
-
-        r = self.name_regex.search(basename)
-        try:
-            name = r.groupdict()["name"]
-        except Exception as err:
-            self.info["reason"] = str(err)
-            name = None
-
-        log.debug("Regex name: %s", name)
-        return name

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -32,7 +32,7 @@ from typing import Optional
 from dsdev_utils.paths import ChDir, remove_any
 import packaging.version
 
-from pyupdater.cli.options import VALID_CHANNELS
+from pyupdater import settings
 from pyupdater.utils import parse_archive_name
 from pyupdater.utils.exceptions import PackageHandlerError, UtilsError
 
@@ -160,7 +160,7 @@ class Package(object):
         if self.version.is_prerelease:
             # alpha or beta
             channel_index = "ab".index(self.version.pre[0])
-        return VALID_CHANNELS[channel_index]
+        return settings.VALID_CHANNELS[channel_index]
 
     def extract_info(self, package):
         """Gets version number, platform & hash for package.

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -25,7 +25,6 @@
 from __future__ import unicode_literals
 import logging
 import os
-import re
 import sys
 from typing import Optional
 
@@ -34,32 +33,9 @@ import packaging.version
 
 from pyupdater import settings
 from pyupdater.utils import parse_archive_name
-from pyupdater.utils.exceptions import PackageHandlerError, UtilsError
+from pyupdater.utils.exceptions import UtilsError
 
 log = logging.getLogger(__name__)
-
-
-def parse_platform(name):
-    """Parses platfrom name from given string
-
-    Args:
-
-        name (str): Name to be parsed
-
-    Returns:
-
-        (str): Platform name
-    """
-    log.debug('Parsing "%s" for platform info', name)
-    try:
-        re_str = r"-(?P<platform>arm(64)?|mac|nix(64)?|win)-"
-        data = re.compile(re_str).search(name)
-        platform_name = data.groupdict()["platform"]
-        log.debug("Platform name is: %s", platform_name)
-    except AttributeError:
-        raise PackageHandlerError("Could not parse platform from filename")
-
-    return platform_name
 
 
 def remove_previous_versions(directory, filename):

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -32,7 +32,7 @@ from dsdev_utils.paths import ChDir, remove_any
 import packaging.version
 
 from pyupdater import settings
-from pyupdater.utils import parse_archive_name
+from pyupdater.utils import parse_archive_name, PyuVersion
 from pyupdater.utils.exceptions import UtilsError
 
 log = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ class Package(object):
             filename = str(filename)
 
         self.name = None
-        self.version: Optional[packaging.version.Version] = None
+        self.version: Optional[PyuVersion] = None
         self.filename = os.path.basename(filename)
         self.file_hash = None
         self.file_size = None
@@ -176,7 +176,7 @@ class Package(object):
             # Parse PEP440 version string
             # todo: Release notes should mention that Package.version is now a
             #  packaging.version.Version object instead of a string.
-            self.version = packaging.version.Version(parts["version"])
+            self.version = PyuVersion(parts["version"])
             log.debug("Got version info")
         except TypeError:
             msg = "Failed to parse package filename"

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -131,7 +131,7 @@ class Package(object):
     """
 
     # Used to parse name from archive filename
-    name_regex = re.compile(r"(?P<name>[\w -]+)-[arm|mac|nix|win]")
+    name_regex = re.compile(r"(?P<name>[\w -]+)-(arm|mac|nix|win)")
 
     def __init__(self, filename):
         if sys.version_info[1] == 5:

--- a/pyupdater/core/package_handler/package.py
+++ b/pyupdater/core/package_handler/package.py
@@ -192,15 +192,13 @@ class Package(object):
 
         log.debug(f"Extracting update archive info for: {package_basename}")
         parts = parse_archive_name(package_basename)
-        self.name = parts["app_name"]
-        self.platform = parts["platform"]
         msg = None
         try:
             # parse PEP440 version string
             self.version = packaging.version.Version(parts["version"])
             log.debug("Got version info")
         except TypeError:
-            msg = "Package filename does not match expected format"
+            msg = "Failed to parse package filename"
         except packaging.version.InvalidVersion:
             msg = "Package version may not be PEP440 compliant"
         finally:
@@ -209,6 +207,7 @@ class Package(object):
                 self.info["reason"] = reason
                 log.error(reason)
                 return
-
+        self.name = parts["app_name"]
+        self.platform = parts["platform"]
         self.info["status"] = True
         log.debug("Info extraction complete")

--- a/pyupdater/core/package_handler/patch.py
+++ b/pyupdater/core/package_handler/patch.py
@@ -58,7 +58,7 @@ class Patch(object):
         self._filename = kwargs.get("filename")
         self._files_dir = kwargs.get("files_dir")
         self._new_dir = kwargs.get("new_dir")
-        self._json_data = kwargs.get("json_data")
+        self._version_data = kwargs.get("version_data")
         self._config = kwargs.get("config")
         self._test = kwargs.get("test", False)
 
@@ -95,8 +95,8 @@ class Patch(object):
     def _check_make_patch(self):
         # Check to see if previous version is available to
         # make patch updates. Also calculates patch number
-        if self._json_data.get("latest") is not None:
-            log.debug(json.dumps(self._json_data["latest"], indent=2))
+        if self._version_data.get("latest") is not None:
+            log.debug(json.dumps(self._version_data["latest"], indent=2))
         log.debug("Checking if patch creation is possible")
         if bsdiff4 is None:
             log.warning("Bsdiff is missing. Cannot create patches")
@@ -120,14 +120,14 @@ class Patch(object):
                 # If latest not available in version file. Exit
                 try:
                     log.debug("Looking for %s on %s", _name, _plat)
-                    latest = self._json_data["latest"][_name][_channel][_plat]
+                    latest = self._version_data["latest"][_name][_channel][_plat]
                     log.debug("Found latest version for patches: %s", latest)
                 except KeyError:
                     log.debug("Cannot find latest version in version meta")
                     return
                 try:
                     u_key = settings.UPDATES_KEY
-                    latest_platform = self._json_data[u_key][_name][latest]
+                    latest_platform = self._version_data[u_key][_name][latest]
                     log.debug("Found latest platform for patches")
                     try:
                         filename = latest_platform[_plat]["filename"]

--- a/pyupdater/core/package_handler/patch.py
+++ b/pyupdater/core/package_handler/patch.py
@@ -95,8 +95,8 @@ class Patch(object):
     def _check_make_patch(self):
         # Check to see if previous version is available to
         # make patch updates. Also calculates patch number
-        if self._version_data.get("latest") is not None:
-            log.debug(json.dumps(self._version_data["latest"], indent=2))
+        if self._version_data.get(settings.LATEST_KEY) is not None:
+            log.debug(json.dumps(self._version_data[settings.LATEST_KEY], indent=2))
         log.debug("Checking if patch creation is possible")
         if bsdiff4 is None:
             log.warning("Bsdiff is missing. Cannot create patches")
@@ -120,7 +120,7 @@ class Patch(object):
                 # If latest not available in version file. Exit
                 try:
                     log.debug("Looking for %s on %s", _name, _plat)
-                    latest = self._version_data["latest"][_name][_channel][_plat]
+                    latest = self._version_data[settings.LATEST_KEY][_name][_channel][_plat]
                     log.debug("Found latest version for patches: %s", latest)
                 except KeyError:
                     log.debug("Cannot find latest version in version meta")

--- a/pyupdater/settings.py
+++ b/pyupdater/settings.py
@@ -57,6 +57,7 @@ USER_DATA_FOLDER = "pyu-data"
 
 # Key in version file where value are update meta data
 UPDATES_KEY = "updates"
+LATEST_KEY = "latest"
 
 # Folder on client system where updates are stored
 UPDATE_FOLDER = "update"

--- a/pyupdater/settings.py
+++ b/pyupdater/settings.py
@@ -23,8 +23,6 @@
 # OR OTHER DEALINGS IN THE SOFTWARE.
 # ------------------------------------------------------------------------------
 from __future__ import unicode_literals
-import struct
-import sys
 
 from dsdev_utils import system
 
@@ -67,3 +65,12 @@ UPDATE_FOLDER = "update"
 VERSION_FILE_FILENAME = "versions-{}.gz".format(system.get_system())
 VERSION_FILE_FILENAME_COMPAT = "versions.gz"
 KEY_FILE_FILENAME = "keys.gz"
+
+# The VALID_CHANNELS index corresponds with the <release> value in the internal
+# version format, <major>.<minor>.<patch>.<release>.<release version>,
+# as defined here:
+# https://github.com/Digital-Sapphire/dsdev-utils/blob/1.3.0/dsdev_utils/helpers.py#L192
+# Also see:
+# https://github.com/Digital-Sapphire/PyUpdater/blob/4.0/pyupdater/client/updates.py#L198
+# https://github.com/Digital-Sapphire/PyUpdater/blob/4.0/pyupdater/core/package_handler/package.py#L188
+VALID_CHANNELS = ["alpha", "beta", "stable"]

--- a/pyupdater/utils/__init__.py
+++ b/pyupdater/utils/__init__.py
@@ -27,6 +27,7 @@ import io
 import logging
 import json
 import os
+import re
 import shutil
 import subprocess
 import tarfile
@@ -314,6 +315,25 @@ def make_archive(name, target, version, archive_format):
 
     log.debug("Archive output filename: %s", output_filename)
     return output_filename
+
+
+def parse_archive_name(filename):
+    """
+    Parse a filename created by make_archive(), to extract app_name, platform,
+    version, and extension strings.
+
+    We do not impose any versioning requirements yet, such as defined in
+    packaging.version.VERSION_PATTERN.
+    """
+    archive_name_pattern = (
+        r"^(?P<app_name>[\w -]+)"
+        r"-"
+        r"(?P<platform>arm(64)?|mac|nix(64)?|win)"
+        r"-"
+        r"(?P<version>.+)"
+        r"(?P<extension>\.zip|\.tar\.gz)$")
+    match = re.search(pattern=archive_name_pattern, string=filename)
+    return match.groupdict() if match else None
 
 
 def remove_dot_files(files):

--- a/pyupdater/utils/__init__.py
+++ b/pyupdater/utils/__init__.py
@@ -523,6 +523,9 @@ class VersionShim(packaging.version.Version):
             if channel < 2:
                 version = re_obj.sub(
                     r"\1" + cls.pyu_channels[channel] + r"\3", version)
+            elif channel == 2:
+                # remove the ".2.0" from the internal version number
+                version = re_obj.sub(r"\1", version)
         return version
 
     def pyu_format(self) -> str:

--- a/pyupdater/utils/__init__.py
+++ b/pyupdater/utils/__init__.py
@@ -218,7 +218,7 @@ def get_size_in_bytes(filename):
     return size
 
 
-def create_asset_archive(name, version):
+def create_asset_archive(name, version: str):
     """Used to make archives of file or dir. Zip on windows and tar.gz
     on all other platforms
 
@@ -253,7 +253,7 @@ def create_asset_archive(name, version):
     return output_filename
 
 
-def make_archive(name, target, version, archive_format):
+def make_archive(name, target, version: str, archive_format):
     """Used to make archives of file or dir. Zip on windows and tar.gz
     on all other platforms
 

--- a/pyupdater/utils/__init__.py
+++ b/pyupdater/utils/__init__.py
@@ -324,6 +324,9 @@ def parse_archive_name(filename):
 
     We do not impose any versioning requirements yet, such as defined in
     packaging.version.VERSION_PATTERN.
+
+    todo: Mention that package.parse_platform has been removed,
+     use parse_archive_name instead.
     """
     archive_name_pattern = (
         r"^(?P<app_name>[\w -]+)"

--- a/pyupdater/utils/__init__.py
+++ b/pyupdater/utils/__init__.py
@@ -255,7 +255,7 @@ def create_asset_archive(name, version: str):
     return output_filename
 
 
-def make_archive(name, target, version: str, archive_format):
+def make_archive(name, target, app_version: str, archive_format):
     """Used to make archives of file or dir. Zip on windows and tar.gz
     on all other platforms
 
@@ -297,7 +297,7 @@ def make_archive(name, target, version: str, archive_format):
 
     file_dir = os.path.dirname(os.path.abspath(target))
     filename = "{}-{}-{}".format(
-        os.path.splitext(name)[0], system.get_system(), version
+        os.path.splitext(name)[0], system.get_system(), app_version
     )
     # Only use zip on windows.
     # Zip does not preserve file permissions on nix & mac

--- a/pyupdater/utils/builder.py
+++ b/pyupdater/utils/builder.py
@@ -221,14 +221,14 @@ class Builder(object):  # pragma: no cover
                 app_name = temp_name + ".exe"
             else:
                 app_name = temp_name
-            version = self.args.app_version
+            app_version = self.args.app_version
             log.debug("Temp Name: %s", temp_name)
             log.debug("Appname: %s", app_name)
-            log.debug("Version: %s", version)
+            log.debug("Version: %s", app_version)
 
             # Time for some archive creation!
             filename = make_archive(
-                self.app_name, app_name, version, self.args.archive_format
+                self.app_name, app_name, app_version, self.args.archive_format
             )
             log.debug("Archive name: %s", filename)
             if self.args.keep is False:

--- a/pyupdater/utils/builder.py
+++ b/pyupdater/utils/builder.py
@@ -242,7 +242,7 @@ class Builder(object):  # pragma: no cover
 
 
 class ExternalLib(object):
-    def __init__(self, name, version):
+    def __init__(self, name, version: str):
         self.name = name
         self.version = version
 

--- a/pyupdater/utils/builder.py
+++ b/pyupdater/utils/builder.py
@@ -29,8 +29,6 @@ import os
 import sys
 import time
 
-from dsdev_utils.exceptions import VersionError
-from dsdev_utils.helpers import Version
 from dsdev_utils.paths import ChDir, remove_any
 from dsdev_utils.system import get_system
 from PyInstaller.__main__ import run as pyi_build
@@ -171,19 +169,6 @@ class Builder(object):  # pragma: no cover
 
     # Actually creates executable from spec file
     def _build(self, spec_file_path):
-        try:
-            Version(self.args.app_version)
-        except VersionError:
-            log.error("Version format incorrect: %s", self.args.app_version)
-            log.error(
-                """Valid version numbers: 0.10.0, 1.1b, 1.2.1a3
-
-        Visit url for more info:
-
-            http://semver.org/
-                      """
-            )
-            sys.exit(1)
         build_args = []
         if self.args.clean is True:
             build_args.append("--clean")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ appdirs>=1.4.3
 bsdiff4
 certifi>=2019.3.9
 dsdev-utils>=1.0.4
+packaging>=21.3
 pyinstaller>=3.0
 pynacl>=1.4.0
 stevedore>=1.30.1, <4.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@
 # ------------------------------------------------------------------------------
 from __future__ import unicode_literals
 
+import argparse
 import io
 import os
 
@@ -115,7 +116,7 @@ class TestBuilder(object):
         add_build_parser(subparser)
         with pytest.raises(SystemExit):
             parser.parse_known_args(["build", "--app-version"])
-        with pytest.raises(ValueError):
+        with pytest.raises(SystemExit):
             parser.parse_known_args(["build", "--app-version", "invalid"])
 
     @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,25 @@ class TestBuilder(object):
         with pytest.raises(SystemExit):
             parser.parse_known_args(["build"])
 
+    def test_build_options_app_version_invalid(self, parser):
+        subparser = make_subparser(parser)
+        add_build_parser(subparser)
+        with pytest.raises(SystemExit):
+            parser.parse_known_args(["build", "--app-version"])
+        with pytest.raises(ValueError):
+            parser.parse_known_args(["build", "--app-version", "invalid"])
+
+    @pytest.mark.parametrize(
+        "version_string",
+        ["1", "1.0", "1.0.0", "1.2.3a5", "2021.0", "2021.0beta+10-g9cddff1"]
+    )
+    def test_build_options_app_version_valid(self, parser, version_string):
+        subparser = make_subparser(parser)
+        add_build_parser(subparser)
+        args = ["build", "--app-version", version_string]
+        opts, other = parser.parse_known_args(args)
+        assert opts.app_version == args[2]
+
     def test_build_no_arguments(self, parser, pyu):
         pyu.setup()
         subparser = make_subparser(parser)
@@ -120,6 +139,7 @@ class TestBuilder(object):
                 f.write('print("Hello, World!")')
             opts, other = parser.parse_known_args(["build", "app.py"])
             commands._cmd_build(opts, other)
+
 
 
 @pytest.mark.usefixtures("cleandir", "parser")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,7 +35,8 @@ from dsdev_utils.paths import ChDir, remove_any
 import pytest
 
 from pyupdater.client import Client
-from pyupdater.client.updates import gen_user_friendly_version, get_highest_version
+from pyupdater.client.updates import (
+    gen_user_friendly_version, gen_pep440_version, get_highest_version)
 from tconfig import TConfig
 
 
@@ -221,6 +222,20 @@ class TestGenVersion(object):
         assert gen_user_friendly_version("1.2.2.2.0") == "1.2.2"
         assert gen_user_friendly_version("2.0.5.0.3") == "2.0.5 Alpha 3"
         assert gen_user_friendly_version("2.2.1.1.0") == "2.2.1 Beta"
+
+
+class TestGenPEP440Version(object):
+    @pytest.mark.parametrize(
+        ["internal_version", "expected"],
+        [("4.4.3.2.0", "4.4.3.2.0"), ("0.0.0.2.3", "0.0.0.2.3"),
+         ("4.4.2.0.5", "4.4.2.alpha.5"), ("4.4.1.1.0", "4.4.1.beta.0")]
+    )
+    def test_valid(self, internal_version, expected):
+        assert gen_pep440_version(internal_version) == expected
+
+    def test_invalid(self):
+        with pytest.raises(ValueError):
+            gen_pep440_version("invalid")
 
 
 class TestChannelStrict(object):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,8 +33,7 @@ from dsdev_utils.system import get_system
 from dsdev_utils.paths import ChDir, remove_any
 import pytest
 
-from pyupdater.client import Client
-from pyupdater.client.updates import get_highest_version
+from pyupdater.client import Client, get_highest_version
 from tconfig import TConfig
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,6 @@ from __future__ import unicode_literals
 
 import json
 import os
-import packaging.version
 import time
 
 from dsdev_utils.helpers import EasyAccessDict
@@ -36,8 +35,7 @@ from dsdev_utils.paths import ChDir, remove_any
 import pytest
 
 from pyupdater.client import Client
-from pyupdater.client.updates import (
-    gen_user_friendly_version, gen_pep440_version, get_highest_version)
+from pyupdater.client.updates import get_highest_version
 from tconfig import TConfig
 
 
@@ -215,34 +213,6 @@ class TestExtract(object):
                 remove_any(f)
         if get_system() != "win":
             assert update.extract() is False
-
-
-class TestGenVersion(object):
-    def test1(self):
-        assert gen_user_friendly_version("1.0.0.2.0") == "1.0"
-        assert gen_user_friendly_version("1.2.2.2.0") == "1.2.2"
-        assert gen_user_friendly_version("2.0.5.0.3") == "2.0.5 Alpha 3"
-        assert gen_user_friendly_version("2.2.1.1.0") == "2.2.1 Beta"
-
-
-class TestGenPEP440Version(object):
-    @pytest.mark.parametrize(
-        ["internal_version", "expected"],
-        [("4.4.3.2.0", "4.4.3.2.0"), ("0.0.0.2.3", "0.0.0.2.3"),
-         ("4.4.2.0.5", "4.4.2.alpha.5"), ("4.4.1.1.0", "4.4.1.beta.0")]
-    )
-    def test_valid(self, internal_version, expected):
-        assert gen_pep440_version(internal_version) == expected
-
-    def test_invalid(self):
-        with pytest.raises(ValueError):
-            gen_pep440_version("invalid")
-
-    def test_packaging_version_dependency(self):
-        # make sure packaging.version.parse() can actually parse our
-        # "PEP440-compatible" strings
-        assert str(packaging.version.parse("4.4.2.2.5")) == "4.4.2.2.5"
-        assert str(packaging.version.parse("4.4.2.alpha.5")) == "4.4.2a5"
 
 
 class TestChannelStrict(object):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -231,11 +231,11 @@ class TestGetHighestVersion(object):
     )
     def test_strict(self, channel, expected):
         args = ("Acme", "mac", channel, self.version_data)
-        assert str(get_highest_version(*args, strict=True)) == expected
+        assert get_highest_version(*args, strict=True).pyu_format() == expected
 
     def test_not_strict(self):
         args = ("Acme", "mac", "alpha", self.version_data)
-        assert str(get_highest_version(*args, strict=False)) == "4.4.3.2.0"
+        assert get_highest_version(*args, strict=False).pyu_format() == "4.4.3.2.0"
 
     def test_missing_stable(self):
         data = self.version_data.copy()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,6 +27,7 @@ from __future__ import unicode_literals
 
 import json
 import os
+import packaging.version
 import time
 
 from dsdev_utils.helpers import EasyAccessDict
@@ -236,6 +237,12 @@ class TestGenPEP440Version(object):
     def test_invalid(self):
         with pytest.raises(ValueError):
             gen_pep440_version("invalid")
+
+    def test_packaging_version_dependency(self):
+        # make sure packaging.version.parse() can actually parse our
+        # "PEP440-compatible" strings
+        assert str(packaging.version.parse("4.4.2.2.5")) == "4.4.2.2.5"
+        assert str(packaging.version.parse("4.4.2.alpha.5")) == "4.4.2a5"
 
 
 class TestChannelStrict(object):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -94,7 +94,7 @@ class TestSetup(object):
         filesystem_data = filesystem_data.decode()
         filesystem_data = json.loads(filesystem_data)
         del filesystem_data["signature"]
-        assert client.json_data == filesystem_data
+        assert client.version_data == filesystem_data
 
     def test_url_str_attr(self):
         t_config = TConfig()

--- a/tests/test_package_handler.py
+++ b/tests/test_package_handler.py
@@ -28,6 +28,7 @@ import io
 import os
 
 from dsdev_utils.paths import ChDir
+import packaging.version
 import pytest
 
 from pyupdater import settings
@@ -95,7 +96,7 @@ class TestPackage(object):
         p1 = Package(shared_datadir / test_file)
 
         assert p1.name == "Acme"
-        assert p1.version == "4.1.0.2.0"
+        assert str(p1.version) == "4.1"
         assert p1.filename == test_file
         assert p1.platform == "mac"
         assert p1.channel == "stable"
@@ -106,7 +107,7 @@ class TestPackage(object):
         p1 = Package(shared_datadir / test_file)
 
         assert p1.name == "with spaces"
-        assert p1.version == "0.0.1.1.1"
+        assert str(p1.version) == "0.0.1b1"
         assert p1.filename == test_file
         assert p1.platform == "nix"
         assert p1.channel == "beta"
@@ -117,7 +118,7 @@ class TestPackage(object):
         p1 = Package(shared_datadir / test_file)
 
         assert p1.name == "with spaces"
-        assert p1.version == "0.0.1.0.2"
+        assert str(p1.version) == "0.0.1a2"
         assert p1.filename == test_file
         assert p1.platform == "win"
         assert p1.channel == "alpha"
@@ -149,7 +150,7 @@ class TestPackage(object):
     def test_package_bad_platform(self, shared_datadir):
         filename = "pyu-wi-1.1.tar.gz"
         p = Package(shared_datadir / filename)
-        out = "filename does not match expected format"
+        out = "failed to parse package filename"
         assert out in p.info["reason"].lower()
 
 

--- a/tests/test_package_handler.py
+++ b/tests/test_package_handler.py
@@ -29,13 +29,13 @@ import os
 import pathlib
 
 from dsdev_utils.paths import ChDir
-import packaging.version
 import pytest
 
 from pyupdater import settings
 from pyupdater.core.package_handler import PackageHandler
 from pyupdater.core.package_handler.package import Package
 from pyupdater.core.package_handler.patch import Patch
+from pyupdater.utils import PyuVersion
 from pyupdater.utils.config import Config
 from pyupdater.utils.exceptions import PackageHandlerError
 

--- a/tests/test_package_handler.py
+++ b/tests/test_package_handler.py
@@ -33,7 +33,7 @@ import pytest
 
 from pyupdater import settings
 from pyupdater.core.package_handler import PackageHandler
-from pyupdater.core.package_handler.package import Package, parse_platform
+from pyupdater.core.package_handler.package import Package
 from pyupdater.core.package_handler.patch import Patch
 from pyupdater.utils.config import Config
 from pyupdater.utils.exceptions import PackageHandlerError
@@ -64,16 +64,6 @@ class TestUtils(object):
         config.from_object(t_config)
         p = PackageHandler(config)
         p.process_packages()
-
-    def test_parse_platform(self):
-        assert parse_platform("app-mac-0.1.0.tar.gz") == "mac"
-        assert parse_platform("app-win-1.0.0.zip") == "win"
-        assert parse_platform("Email Parser-mac-0.2.0.tar.gz") == "mac"
-        assert parse_platform("Hangman-nix-0.0.1b1.zip") == "nix"
-
-    def test_parse_platform_fail(self):
-        with pytest.raises(PackageHandlerError):
-            parse_platform("app-nex-1.0.0.tar.gz")
 
 
 @pytest.mark.usefixtures("cleandir", "pyu")

--- a/tests/test_package_handler.py
+++ b/tests/test_package_handler.py
@@ -194,7 +194,7 @@ class TestPatch(object):
             "filename": full_path,
             "files_dir": self.files_dir,
             "new_dir": self.new_dir,
-            "json_data": version_data,
+            "version_data": version_data,
             "pkg_info": pkg,
             "config": config,
             "test": True,

--- a/tests/test_package_handler.py
+++ b/tests/test_package_handler.py
@@ -26,6 +26,7 @@ from __future__ import unicode_literals
 
 import io
 import os
+import pathlib
 
 from dsdev_utils.paths import ChDir
 import packaging.version
@@ -68,7 +69,7 @@ class TestUtils(object):
 
 @pytest.mark.usefixtures("cleandir", "pyu")
 class TestExecution(object):
-    def test_process_packages(self):
+    def test_process_packages_empty(self):
         data_dir = os.getcwd()
         t_config = TConfig()
         t_config.DATA_DIR = data_dir
@@ -77,6 +78,26 @@ class TestExecution(object):
         config.from_object(t_config)
         p = PackageHandler(config)
         p.process_packages()
+
+    def test_process_packages_new_stable(self):
+        data_dir = pathlib.Path.cwd()
+        t_config = TConfig()
+        t_config.DATA_DIR = str(data_dir)
+        t_config.UPDATE_PATCHES = False
+        config = Config()
+        config.from_object(t_config)
+        p = PackageHandler(config)
+        # create dummy archive file
+        new_archive_version = "4.1"
+        new_archive_name = f"Acme-mac-{new_archive_version}.tar.gz"
+        new_archive_path = pathlib.Path(p.new_dir) / new_archive_name
+        new_archive_path.touch()
+        # process package
+        p.process_packages()
+        deploy_archive_path = pathlib.Path(p.deploy_dir) / new_archive_name
+        assert deploy_archive_path.exists()
+        assert new_archive_name in str(p.version_data[settings.UPDATES_KEY])
+        assert new_archive_version in str(p.version_data[settings.LATEST_KEY])
 
 
 @pytest.mark.usefixtures("cleandir")

--- a/tests/test_package_handler.py
+++ b/tests/test_package_handler.py
@@ -141,17 +141,16 @@ class TestPackage(object):
             "Not a supported archive format: " "{}".format(test_file_2)
         )
 
-    def test_package_bad_version(self, shared_datadir):
+    def test_package_only_major_version(self, shared_datadir):
         filename = "pyu-win-1.tar.gz"
         p = Package(shared_datadir / filename)
-        out = "Package version not formatted correctly: {}"
-        assert p.info["reason"] == out.format(filename)
+        assert p.info["reason"] == ''
 
     def test_package_bad_platform(self, shared_datadir):
         filename = "pyu-wi-1.1.tar.gz"
         p = Package(shared_datadir / filename)
-        out = "Package platform not formatted correctly"
-        assert p.info["reason"] == out
+        out = "filename does not match expected format"
+        assert out in p.info["reason"].lower()
 
 
 @pytest.mark.usefixtures("cleandir")

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -24,11 +24,13 @@
 # ------------------------------------------------------------------------------
 from __future__ import unicode_literals, print_function
 import json
+import logging
 import os
 
 import pytest
 
 from pyupdater.client.patcher import Patcher
+from pyupdater.utils import PyuVersion
 
 
 def cb1(status):
@@ -50,15 +52,6 @@ update_data = {
     "platform": "mac",
     "progress_hooks": [cb1, cb2],
 }
-
-
-class TestPatcher(object):
-    def test_current_version(self):
-        data = update_data.copy()
-        data["current_version"] = "4.1.0.0.0"
-        data["current_file_hash"] = "some valid hash"
-        p = Patcher(**data)
-        assert str(p.current_version) == data["current_version"]
 
 
 # noinspection PyStatementEffect,PyStatementEffect

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -52,6 +52,15 @@ update_data = {
 }
 
 
+class TestPatcher(object):
+    def test_current_version(self):
+        data = update_data.copy()
+        data["current_version"] = "4.1.0.0.0"
+        data["current_file_hash"] = "some valid hash"
+        p = Patcher(**data)
+        assert str(p.current_version) == data["current_version"]
+
+
 # noinspection PyStatementEffect,PyStatementEffect
 @pytest.mark.usefixtures("cleandir")
 class TestFails(object):

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -68,31 +68,31 @@ class TestFails(object):
     base_binary = "Acme-mac-4.1.tar.gz"
 
     @pytest.fixture
-    def json_data(self, shared_datadir):
+    def version_data(self, shared_datadir):
         version_data_str = (shared_datadir / "version.json").read_text()
         return json.loads(version_data_str)
 
-    def test_no_base_binary(self, json_data):
+    def test_no_base_binary(self, version_data):
         assert os.listdir(os.getcwd()) == []
         data = update_data.copy()
         data["update_folder"] = os.getcwd()
-        data["json_data"] = json_data
+        data["version_data"] = version_data
         p = Patcher(**data)
         assert p.start() is False
 
-    def test_bad_hash_current_version(self, shared_datadir, json_data):
+    def test_bad_hash_current_version(self, shared_datadir, version_data):
         data = update_data.copy()
         data["update_folder"] = str(shared_datadir)
-        data["json_data"] = json_data
+        data["version_data"] = version_data
         data["current_file_hash"] = "Thisisabadhash"
         p = Patcher(**data)
         assert p.start() is False
 
     @pytest.mark.run(order=8)
-    def test_missing_version(self, shared_datadir, json_data):
+    def test_missing_version(self, shared_datadir, version_data):
         data = update_data.copy()
         data["update_folder"] = str(shared_datadir)
-        data["json_data"] = json_data
+        data["version_data"] = version_data
         data["latest_version"] = "0.0.4.2.0"
         p = Patcher(**data)
         assert p.start() is False
@@ -105,20 +105,20 @@ class TestExecution(object):
     base_binary = "Acme-mac-4.1.tar.gz"
 
     @pytest.fixture
-    def json_data(self, shared_datadir):
+    def version_data(self, shared_datadir):
         version_data_str = (shared_datadir / "version.json").read_text()
         return json.loads(version_data_str)
 
     @pytest.mark.run(order=7)
-    def test_execution(self, shared_datadir, json_data):
+    def test_execution(self, shared_datadir, version_data):
         data = update_data.copy()
         data["update_folder"] = str(shared_datadir)
-        data["json_data"] = json_data
+        data["version_data"] = version_data
         data["channel"] = "stable"
         p = Patcher(**data)
         assert p.start() is True
 
-    def test_execution_callback(self, shared_datadir, json_data):
+    def test_execution_callback(self, shared_datadir, version_data):
         def cb(status):
             assert "downloaded" in status.keys()
             assert "total" in status.keys()
@@ -127,7 +127,7 @@ class TestExecution(object):
 
         data = update_data.copy()
         data["update_folder"] = str(shared_datadir)
-        data["json_data"] = json_data
+        data["version_data"] = version_data
         data["channel"] = "stable"
         data["progress_hooks"] = [cb]
         p = Patcher(**data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,7 +168,7 @@ class TestUtils(object):
         assert p.bucket == "test_bucket"
 
 
-class TestVersionShim(object):
+class TestPyuVersion(object):
     @pytest.mark.parametrize(
         ["internal_version", "expected"],
         [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -172,8 +172,9 @@ class TestVersionShim(object):
     @pytest.mark.parametrize(
         ["internal_version", "expected"],
         [
-            ("4.4.3.2.0", "4.4.3.2.0"),
-            ("0.0.0.2.3", "0.0.0.2.3"),
+            ("4.4.3.2.0", "4.4.3"),
+            ("0.0.0.2.3", "0.0.0"),
+            ("0.0.0.3.0", "0.0.0.3.0"),  # not an internal version number
             ("4.4.2.0.5", "4.4.2a5"),
             ("4.4.1.1.0", "4.4.1b0"),
             ("1.2.3a5+something", "1.2.3a5+something"),
@@ -184,7 +185,11 @@ class TestVersionShim(object):
     )
     def test_ensure_pep440_compat(self, internal_version, expected):
         # Note that non-internal versions (including invalid ones) are passed
-        # unmodified, as we leave the actual parsing to packaging.version
+        # unmodified, as we leave the actual parsing to packaging.version.
+        # Note that the trailing ".2.0" must be removed from the internal
+        # version number, otherwise it is interpreted as part of the "stable"
+        # release number, so that e.g. 1.0.0.2.0 > 1.0.0 would return True (
+        # when using internal version numbers, these should be equal)
         assert VersionShim.ensure_pep440_compat(internal_version) == expected
 
     @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,6 +37,7 @@ from pyupdater.utils import (
     PluginManager,
     remove_dot_files,
     run,
+    VersionShim,
 )
 
 
@@ -57,14 +58,15 @@ class TestUtils(object):
 
     @pytest.mark.parametrize(
         ["filename", "expected"],
-        [("Acme-mac-4.1.tar.gz", ("Acme", "mac", "4.1", ".tar.gz")),
-         ("with spaces-nix-0.0.1b1.zip", ("with spaces", "nix", "0.0.1b1", ".zip")),
-         ("with spaces-win-0.0.1a2.zip", ("with spaces", "win", "0.0.1a2", ".zip")),
-         ("pyu-win-1.tar.gz", ("pyu", "win", "1", ".tar.gz")),
-         ("pyu-win-0.0.2.xz", None),
-         ("pyu-wi-1.1.tar.gz", None),
-         ("anything", None),
-         ]
+        [
+            ("Acme-mac-4.1.tar.gz", ("Acme", "mac", "4.1", ".tar.gz")),
+            ("with spaces-nix-0.0.1b1.zip", ("with spaces", "nix", "0.0.1b1", ".zip")),
+            ("with spaces-win-0.0.1a2.zip", ("with spaces", "win", "0.0.1a2", ".zip")),
+            ("pyu-win-1.tar.gz", ("pyu", "win", "1", ".tar.gz")),
+            ("pyu-win-0.0.2.xz", None),
+            ("pyu-wi-1.1.tar.gz", None),
+            ("anything", None),
+        ],
     )
     def test_parse_archive_name(self, filename, expected):
         parts = parse_archive_name(filename)
@@ -164,3 +166,37 @@ class TestUtils(object):
 
         p = pm.get_plugin("test", True)
         assert p.bucket == "test_bucket"
+
+
+class TestVersionShim(object):
+    @pytest.mark.parametrize(
+        ["internal_version", "expected"],
+        [
+            ("4.4.3.2.0", "4.4.3.2.0"),
+            ("0.0.0.2.3", "0.0.0.2.3"),
+            ("4.4.2.0.5", "4.4.2a5"),
+            ("4.4.1.1.0", "4.4.1b0"),
+            ("1.2.3a5+something", "1.2.3a5+something"),
+            ("1.2.3", "1.2.3"),
+            ("v1.2.3", "v1.2.3"),
+            ("invalid", "invalid"),
+        ],
+    )
+    def test_ensure_pep440_compat(self, internal_version, expected):
+        # Note that non-internal versions (including invalid ones) are passed
+        # unmodified, as we leave the actual parsing to packaging.version
+        assert VersionShim.ensure_pep440_compat(internal_version) == expected
+
+    @pytest.mark.parametrize(
+        ["pep440_version", "expected"],
+        [
+            ("1", "1.0.0.2.0"),
+            ("1.0", "1.0.0.2.0"),
+            ("1.0.0", "1.0.0.2.0"),
+            ("1.0.0.0", "1.0.0.2.0"),
+            ("1.2.3a5", "1.2.3.0.5"),
+            ("4.5.6beta8", "4.5.6.1.8"),
+        ],
+    )
+    def test_pyu_format(self, pep440_version, expected):
+        assert VersionShim(pep440_version).pyu_format() == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,7 @@ from pyupdater.utils import (
     check_repo,
     create_asset_archive,
     make_archive,
+    parse_archive_name,
     PluginManager,
     remove_dot_files,
     run,
@@ -53,6 +54,21 @@ class TestUtils(object):
 
         assert os.path.exists(filename1)
         assert os.path.exists(filename2)
+
+    @pytest.mark.parametrize(
+        ["filename", "expected"],
+        [("Acme-mac-4.1.tar.gz", ("Acme", "mac", "4.1", ".tar.gz")),
+         ("with spaces-nix-0.0.1b1.zip", ("with spaces", "nix", "0.0.1b1", ".zip")),
+         ("with spaces-win-0.0.1a2.zip", ("with spaces", "win", "0.0.1a2", ".zip")),
+         ("pyu-win-1.tar.gz", ("pyu", "win", "1", ".tar.gz")),
+         ("pyu-win-0.0.2.xz", None),
+         ("pyu-wi-1.1.tar.gz", None),
+         ("anything", None),
+         ]
+    )
+    def test_parse_archive_name(self, filename, expected):
+        parts = parse_archive_name(filename)
+        assert parts == expected or tuple(parts.values()) == expected
 
     def test_create_asset_archive(self):
         with io.open("hash-test1.dll", "w", encoding="utf-8") as f:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,7 +37,7 @@ from pyupdater.utils import (
     PluginManager,
     remove_dot_files,
     run,
-    VersionShim,
+    PyuVersion,
 )
 
 
@@ -190,7 +190,7 @@ class TestVersionShim(object):
         # version number, otherwise it is interpreted as part of the "stable"
         # release number, so that e.g. 1.0.0.2.0 > 1.0.0 would return True (
         # when using internal version numbers, these should be equal)
-        assert VersionShim.ensure_pep440_compat(internal_version) == expected
+        assert PyuVersion.ensure_pep440_compat(internal_version) == expected
 
     @pytest.mark.parametrize(
         ["pep440_version", "expected"],
@@ -204,4 +204,4 @@ class TestVersionShim(object):
         ],
     )
     def test_pyu_format(self, pep440_version, expected):
-        assert VersionShim(pep440_version).pyu_format() == expected
+        assert PyuVersion(pep440_version).pyu_format() == expected


### PR DESCRIPTION
This is an attempt to fix issue #315 (and issue #299).

- replaced the `dsdev-utils.helpers.Version` by a `PyuVersion` class which is a very thin wrapper around `packaging.version.Version`: just adds ability to convert from/to pyupdater "internal" version, which is used as keys in the versions.gz and config.pyu files.
- pass around (and work with) `Version` objects instead of version strings, where possible
- added some tests
- renamed some variables for consistency and clarity
