### PR TITLE
if no bad packages, say so

### DIFF
--- a/pyupdater/core/package_handler/__init__.py
+++ b/pyupdater/core/package_handler/__init__.py
@@ -208,9 +208,12 @@ class PackageHandler(object):
                         patch_manifest.append(_patch)
 
         if report_errors is True:  # pragma: no cover
-            log.warning("Bad package & reason for being naughty:")
-            for b in bad_packages:
-                log.warning(b.name, b.info["reason"])
+            if not bad_packages:
+                log.warning("No bad packages")
+            else:
+                log.warning("Bad package & reason for being naughty:")
+                for b in bad_packages:
+                    log.warning(b.name, b.info["reason"])
 
         return package_manifest, patch_manifest
 


### PR DESCRIPTION
Naive users (e.g. me) get concerned when they see a message talking about bad packages, and reasons why they are naughty. If there are none, then say so.